### PR TITLE
fix: safe arena node access and pending transactions count API

### DIFF
--- a/src/engine/layers_engine.rs
+++ b/src/engine/layers_engine.rs
@@ -137,6 +137,11 @@ impl LayersEngine {
     pub fn update(&self, dt: f32) -> bool {
         self.engine.update(dt)
     }
+    /// Returns the number of transactions currently pending execution.
+    /// A non-zero value means another call to `update` is needed.
+    pub fn pending_transactions_count(&self) -> usize {
+        self.engine.pending_transactions_count()
+    }
     /// Update the nodes in the scene and returns the bounding box of the changes
     pub fn update_nodes(&self) -> skia_safe::Rect {
         self.engine.update_nodes()

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -664,13 +664,15 @@ impl Engine {
             // if the layer has an id, then remove it from the layout tree
             let mut layout_tree = self.layout_tree.write().unwrap();
 
-            if let Err(_) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            if std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 if let Some(layout_parent) = layout_tree.parent(layout) {
                     if let Err(e) = layout_tree.remove_child(layout_parent, layout) {
                         error!("Failed to remove layout child (node may be freed): {}", e);
                     }
                 }
-            })) {
+            }))
+            .is_err()
+            {
                 error!("layout_detach_layer panicked (likely invalid layout node)");
             }
         }
@@ -727,7 +729,7 @@ impl Engine {
         layer_id: impl Into<&'a NodeRef>,
         parent: impl Into<Option<NodeRef>>,
     ) {
-        if let Err(_) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        if std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let layer_id = layer_id.into();
             if let Some(layer) = self.get_layer(layer_id) {
                 let parent = parent.into();
@@ -737,19 +739,19 @@ impl Engine {
                     scene_root
                 });
 
-                if new_parent.is_none() {
-                    // if we append to a scene without a root, we set the layer as the root
-                    self.scene_set_root(layer);
-                } else {
-                    let new_parent = new_parent.unwrap();
-
+                if let Some(new_parent) = new_parent {
                     self.scene.append_node_to(layer.id, new_parent);
                     self.layout_append_layer(&layer, new_parent);
+                } else {
+                    // if we append to a scene without a root, we set the layer as the root
+                    self.scene_set_root(layer);
                 }
                 // Invalidate hit test node list since tree structure changed
                 self.invalidate_hit_test_node_list();
             }
-        })) {
+        }))
+        .is_err()
+        {
             error!("append_layer panicked (likely invalid layout node)");
         }
     }
@@ -763,7 +765,7 @@ impl Engine {
     /// Prepend the layer to the root of the scene or to a parent node
     /// if the parent is provided
     pub fn prepend_layer(&self, layer: impl Into<Layer>, parent: impl Into<Option<NodeRef>>) {
-        if let Err(_) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        if std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let layer: Layer = layer.into();
             let layer_id = layer.id;
             let parent = parent.into();
@@ -776,18 +778,18 @@ impl Engine {
                 scene_root
             });
 
-            if new_parent.is_none() {
-                // if we append to a scene without a root, we set the layer as the root
-                self.scene_set_root(layer);
-            } else {
-                let new_parent = new_parent.unwrap();
-
+            if let Some(new_parent) = new_parent {
                 self.scene.prepend_node_to(layer_id, new_parent);
                 self.layout_prepend_layer(&layer, new_parent);
+            } else {
+                // if we append to a scene without a root, we set the layer as the root
+                self.scene_set_root(layer);
             }
             // Invalidate hit test node list since tree structure changed
             self.invalidate_hit_test_node_list();
-        })) {
+        }))
+        .is_err()
+        {
             error!("prepend_layer panicked (likely invalid layout node)");
         }
     }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1554,7 +1554,7 @@ impl Engine {
         });
     }
     pub fn get_node_layout_style(&self, node: taffy::NodeId) -> Style {
-        let layout = self.layout_tree.read().unwrap();
+        let layout = self.layout_tree.read().unwrap_or_else(|e| e.into_inner());
         match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| layout.style(node).cloned()))
         {
             Ok(Ok(style)) => style,
@@ -1595,7 +1595,10 @@ impl Engine {
             };
             if style.size != new_size {
                 style.size = new_size;
-                let _ = layout.set_style(node, style);
+                if layout.set_style(node, style).is_err() {
+                    error!("Failed to set node layout style (node may be freed)");
+                    return false;
+                }
                 return true;
             }
             false

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -716,8 +716,7 @@ impl Engine {
         let parent_layout = parent_layout.unwrap();
         let mut layout_tree = self.layout_tree.write().unwrap();
         if let Err(_) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            if let Err(e) = layout_tree
-                .insert_child_at_index(parent_layout, 0, layout) {
+            if let Err(e) = layout_tree.insert_child_at_index(parent_layout, 0, layout) {
                 error!("Failed to insert layout child (node may be freed): {}", e);
             }
             let res = layout_tree.mark_dirty(parent_layout);
@@ -1235,8 +1234,7 @@ impl Engine {
                     .map(|node_id| {
                         let (parent_render_layer, parent_changed) =
                             self.scene.with_arena(|arena| {
-                                let parent_id =
-                                    arena.get(*node_id).and_then(|n| n.parent());
+                                let parent_id = arena.get(*node_id).and_then(|n| n.parent());
                                 let parent_layer = parent_id
                                     .and_then(|pid| arena.get(pid))
                                     .map(|parent_node| parent_node.get().render_layer().clone());
@@ -1555,9 +1553,8 @@ impl Engine {
     }
     pub fn get_node_layout_style(&self, node: taffy::NodeId) -> Style {
         let layout = self.layout_tree.read().unwrap();
-        match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            layout.style(node).cloned()
-        })) {
+        match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| layout.style(node).cloned()))
+        {
             Ok(Ok(style)) => style,
             Ok(Err(e)) => {
                 error!("Failed to get layout style (node may be freed): {}", e);

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -24,6 +24,7 @@
 
 pub use node::SceneNode;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use tracing::error;
 
 mod debug_server;
 
@@ -663,8 +664,14 @@ impl Engine {
             // if the layer has an id, then remove it from the layout tree
             let mut layout_tree = self.layout_tree.write().unwrap();
 
-            if let Some(layout_parent) = layout_tree.parent(layout) {
-                layout_tree.remove_child(layout_parent, layout).unwrap();
+            if let Err(_) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                if let Some(layout_parent) = layout_tree.parent(layout) {
+                    if let Err(e) = layout_tree.remove_child(layout_parent, layout) {
+                        error!("Failed to remove layout child (node may be freed): {}", e);
+                    }
+                }
+            })) {
+                error!("layout_detach_layer panicked (likely invalid layout node)");
             }
         }
     }
@@ -681,10 +688,12 @@ impl Engine {
         }
         let parent_layout = parent_layout.unwrap();
         let mut layout_tree = self.layout_tree.write().unwrap();
-        layout_tree.add_child(parent_layout, layout).unwrap();
+        if let Err(e) = layout_tree.add_child(parent_layout, layout) {
+            error!("Failed to add layout child (node may be freed): {}", e);
+        }
         let res = layout_tree.mark_dirty(parent_layout);
         if let Some(err) = res.err() {
-            println!("layout err {}", err);
+            error!("Failed to mark layout dirty: {}", err);
         }
     }
 
@@ -700,12 +709,13 @@ impl Engine {
         }
         let parent_layout = parent_layout.unwrap();
         let mut layout_tree = self.layout_tree.write().unwrap();
-        layout_tree
-            .insert_child_at_index(parent_layout, 0, layout)
-            .unwrap();
+        if let Err(e) = layout_tree
+            .insert_child_at_index(parent_layout, 0, layout) {
+            error!("Failed to insert layout child (node may be freed): {}", e);
+        }
         let res = layout_tree.mark_dirty(parent_layout);
         if let Some(err) = res.err() {
-            println!("layout err {}", err);
+            error!("Failed to mark layout dirty: {}", err);
         }
     }
 
@@ -717,26 +727,30 @@ impl Engine {
         layer_id: impl Into<&'a NodeRef>,
         parent: impl Into<Option<NodeRef>>,
     ) {
-        let layer_id = layer_id.into();
-        if let Some(layer) = self.get_layer(layer_id) {
-            let parent = parent.into();
-            self.layout_detach_layer(&layer);
-            let new_parent = parent.or_else(|| {
-                let scene_root = *self.scene_root.read().unwrap();
-                scene_root
-            });
+        if let Err(_) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let layer_id = layer_id.into();
+            if let Some(layer) = self.get_layer(layer_id) {
+                let parent = parent.into();
+                self.layout_detach_layer(&layer);
+                let new_parent = parent.or_else(|| {
+                    let scene_root = *self.scene_root.read().unwrap();
+                    scene_root
+                });
 
-            if new_parent.is_none() {
-                // if we append to a scene without a root, we set the layer as the root
-                self.scene_set_root(layer);
-            } else {
-                let new_parent = new_parent.unwrap();
+                if new_parent.is_none() {
+                    // if we append to a scene without a root, we set the layer as the root
+                    self.scene_set_root(layer);
+                } else {
+                    let new_parent = new_parent.unwrap();
 
-                self.scene.append_node_to(layer.id, new_parent);
-                self.layout_append_layer(&layer, new_parent);
+                    self.scene.append_node_to(layer.id, new_parent);
+                    self.layout_append_layer(&layer, new_parent);
+                }
+                // Invalidate hit test node list since tree structure changed
+                self.invalidate_hit_test_node_list();
             }
-            // Invalidate hit test node list since tree structure changed
-            self.invalidate_hit_test_node_list();
+        })) {
+            error!("append_layer panicked (likely invalid layout node)");
         }
     }
 
@@ -749,29 +763,33 @@ impl Engine {
     /// Prepend the layer to the root of the scene or to a parent node
     /// if the parent is provided
     pub fn prepend_layer(&self, layer: impl Into<Layer>, parent: impl Into<Option<NodeRef>>) {
-        let layer: Layer = layer.into();
-        let layer_id = layer.id;
-        let parent = parent.into();
-        self.layout_detach_layer(&layer);
+        if let Err(_) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let layer: Layer = layer.into();
+            let layer_id = layer.id;
+            let parent = parent.into();
+            self.layout_detach_layer(&layer);
 
-        self.layout_detach_layer(&layer);
+            self.layout_detach_layer(&layer);
 
-        let new_parent = parent.or_else(|| {
-            let scene_root = *self.scene_root.read().unwrap();
-            scene_root
-        });
+            let new_parent = parent.or_else(|| {
+                let scene_root = *self.scene_root.read().unwrap();
+                scene_root
+            });
 
-        if new_parent.is_none() {
-            // if we append to a scene without a root, we set the layer as the root
-            self.scene_set_root(layer);
-        } else {
-            let new_parent = new_parent.unwrap();
+            if new_parent.is_none() {
+                // if we append to a scene without a root, we set the layer as the root
+                self.scene_set_root(layer);
+            } else {
+                let new_parent = new_parent.unwrap();
 
-            self.scene.prepend_node_to(layer_id, new_parent);
-            self.layout_prepend_layer(&layer, new_parent);
+                self.scene.prepend_node_to(layer_id, new_parent);
+                self.layout_prepend_layer(&layer, new_parent);
+            }
+            // Invalidate hit test node list since tree structure changed
+            self.invalidate_hit_test_node_list();
+        })) {
+            error!("prepend_layer panicked (likely invalid layout node)");
         }
-        // Invalidate hit test node list since tree structure changed
-        self.invalidate_hit_test_node_list();
     }
 
     pub fn add_layer_to_positioned(&self, layer: impl Into<Layer>, parent: Option<NodeRef>) {
@@ -928,7 +946,7 @@ impl Engine {
     pub fn render_layer<'a>(&self, node_ref: impl Into<&'a NodeRef>) -> Option<RenderLayer> {
         let node_ref = node_ref.into();
         self.scene.with_arena(|arena| {
-            let node = arena.get(node_ref.into())?;
+            let node = arena.get(node_ref.into()).filter(|n| !n.is_removed())?;
             let node = node.get().render_layer().clone();
             Some(node)
         })
@@ -948,6 +966,7 @@ impl Engine {
         let node_ref = node_ref.into();
         self.scene.with_arena(|a| {
             a.get(node_ref.0)
+                .filter(|n| !n.is_removed())
                 .map(|node| {
                     let node = node.get();
                     (node.render_layer.size.width, node.render_layer.size.height)
@@ -1201,7 +1220,8 @@ impl Engine {
                     .map(|node_id| {
                         let (parent_render_layer, parent_changed) =
                             self.scene.with_arena(|arena| {
-                                let parent_id = arena[*node_id].parent();
+                                let parent_id =
+                                    arena.get(*node_id).and_then(|n| n.parent());
                                 let parent_layer = parent_id
                                     .and_then(|pid| arena.get(pid))
                                     .map(|parent_node| parent_node.get().render_layer().clone());
@@ -1520,23 +1540,35 @@ impl Engine {
     }
     pub fn get_node_layout_style(&self, node: taffy::NodeId) -> Style {
         let layout = self.layout_tree.read().unwrap();
-        layout.style(node).unwrap().clone()
+        match layout.style(node) {
+            Ok(style) => style.clone(),
+            Err(e) => {
+                error!("Failed to get layout style (node may be freed): {}", e);
+                Style::default()
+            }
+        }
     }
     pub fn set_node_layout_style(&self, node: taffy::NodeId, style: Style) {
         let mut layout = self.layout_tree.write().unwrap();
-        layout.set_style(node, style).unwrap();
+        if let Err(e) = layout.set_style(node, style) {
+            error!("Failed to set layout style (node may be freed): {}", e);
+        }
     }
 
     pub fn set_node_layout_size(&self, node: taffy::NodeId, size: crate::types::Size) -> bool {
         let mut layout = self.layout_tree.write().unwrap();
-        let mut style = layout.style(node).unwrap().clone();
+        let Some(existing_style) = layout.style(node).ok().cloned() else {
+            error!("Failed to get node layout size (node may be freed)");
+            return false;
+        };
+        let mut style = existing_style;
         let new_size = taffy::geometry::Size {
             width: size.width,
             height: size.height,
         };
         if style.size != new_size {
             style.size = new_size;
-            layout.set_style(node, style).unwrap();
+            let _ = layout.set_style(node, style);
             return true;
         }
         false

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -782,8 +782,6 @@ impl Engine {
             let parent = parent.into();
             self.layout_detach_layer(&layer);
 
-            self.layout_detach_layer(&layer);
-
             let new_parent = parent.or_else(|| {
                 let scene_root = *self.scene_root.read().unwrap();
                 scene_root

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -690,12 +690,16 @@ impl Engine {
         }
         let parent_layout = parent_layout.unwrap();
         let mut layout_tree = self.layout_tree.write().unwrap();
-        if let Err(e) = layout_tree.add_child(parent_layout, layout) {
-            error!("Failed to add layout child (node may be freed): {}", e);
-        }
-        let res = layout_tree.mark_dirty(parent_layout);
-        if let Some(err) = res.err() {
-            error!("Failed to mark layout dirty: {}", err);
+        if let Err(_) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            if let Err(e) = layout_tree.add_child(parent_layout, layout) {
+                error!("Failed to add layout child (node may be freed): {}", e);
+            }
+            let res = layout_tree.mark_dirty(parent_layout);
+            if let Some(err) = res.err() {
+                error!("Failed to mark layout dirty: {}", err);
+            }
+        })) {
+            error!("layout_append_layer panicked (likely invalid layout node)");
         }
     }
 
@@ -711,13 +715,17 @@ impl Engine {
         }
         let parent_layout = parent_layout.unwrap();
         let mut layout_tree = self.layout_tree.write().unwrap();
-        if let Err(e) = layout_tree
-            .insert_child_at_index(parent_layout, 0, layout) {
-            error!("Failed to insert layout child (node may be freed): {}", e);
-        }
-        let res = layout_tree.mark_dirty(parent_layout);
-        if let Some(err) = res.err() {
-            error!("Failed to mark layout dirty: {}", err);
+        if let Err(_) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            if let Err(e) = layout_tree
+                .insert_child_at_index(parent_layout, 0, layout) {
+                error!("Failed to insert layout child (node may be freed): {}", e);
+            }
+            let res = layout_tree.mark_dirty(parent_layout);
+            if let Some(err) = res.err() {
+                error!("Failed to mark layout dirty: {}", err);
+            }
+        })) {
+            error!("layout_prepend_layer panicked (likely invalid layout node)");
         }
     }
 
@@ -1547,38 +1555,56 @@ impl Engine {
     }
     pub fn get_node_layout_style(&self, node: taffy::NodeId) -> Style {
         let layout = self.layout_tree.read().unwrap();
-        match layout.style(node) {
-            Ok(style) => style.clone(),
-            Err(e) => {
+        match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            layout.style(node).cloned()
+        })) {
+            Ok(Ok(style)) => style,
+            Ok(Err(e)) => {
                 error!("Failed to get layout style (node may be freed): {}", e);
+                Style::default()
+            }
+            Err(_) => {
+                error!("get_node_layout_style panicked (likely invalid layout node)");
                 Style::default()
             }
         }
     }
     pub fn set_node_layout_style(&self, node: taffy::NodeId, style: Style) {
         let mut layout = self.layout_tree.write().unwrap();
-        if let Err(e) = layout.set_style(node, style) {
-            error!("Failed to set layout style (node may be freed): {}", e);
+        if let Err(_) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            if let Err(e) = layout.set_style(node, style) {
+                error!("Failed to set layout style (node may be freed): {}", e);
+            }
+        })) {
+            error!("set_node_layout_style panicked (likely invalid layout node)");
         }
     }
 
     pub fn set_node_layout_size(&self, node: taffy::NodeId, size: crate::types::Size) -> bool {
         let mut layout = self.layout_tree.write().unwrap();
-        let Some(existing_style) = layout.style(node).ok().cloned() else {
-            error!("Failed to get node layout size (node may be freed)");
-            return false;
-        };
-        let mut style = existing_style;
-        let new_size = taffy::geometry::Size {
-            width: size.width,
-            height: size.height,
-        };
-        if style.size != new_size {
-            style.size = new_size;
-            let _ = layout.set_style(node, style);
-            return true;
+        match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let Some(existing_style) = layout.style(node).ok().cloned() else {
+                error!("Failed to get node layout size (node may be freed)");
+                return false;
+            };
+            let mut style = existing_style;
+            let new_size = taffy::geometry::Size {
+                width: size.width,
+                height: size.height,
+            };
+            if style.size != new_size {
+                style.size = new_size;
+                let _ = layout.set_style(node, style);
+                return true;
+            }
+            false
+        })) {
+            Ok(result) => result,
+            Err(_) => {
+                error!("set_node_layout_size panicked (likely invalid layout node)");
+                false
+            }
         }
-        false
     }
 
     pub fn scene_layer_at(&self, point: Point) -> Option<NodeRef> {

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -995,6 +995,11 @@ impl Engine {
     pub fn now(&self) -> f32 {
         self.timestamp.read().unwrap().0
     }
+    /// Returns the number of transactions currently scheduled to be executed.
+    /// Use this to determine whether another call to `update` is needed.
+    pub fn pending_transactions_count(&self) -> usize {
+        self.transactions.with_data(|d| d.len())
+    }
     pub fn add_animation_from_transition(
         &self,
         transition: &Transition,

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -690,7 +690,7 @@ impl Engine {
         }
         let parent_layout = parent_layout.unwrap();
         let mut layout_tree = self.layout_tree.write().unwrap();
-        if let Err(_) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        if std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             if let Err(e) = layout_tree.add_child(parent_layout, layout) {
                 error!("Failed to add layout child (node may be freed): {}", e);
             }
@@ -698,7 +698,9 @@ impl Engine {
             if let Some(err) = res.err() {
                 error!("Failed to mark layout dirty: {}", err);
             }
-        })) {
+        }))
+        .is_err()
+        {
             error!("layout_append_layer panicked (likely invalid layout node)");
         }
     }
@@ -715,7 +717,7 @@ impl Engine {
         }
         let parent_layout = parent_layout.unwrap();
         let mut layout_tree = self.layout_tree.write().unwrap();
-        if let Err(_) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        if std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             if let Err(e) = layout_tree.insert_child_at_index(parent_layout, 0, layout) {
                 error!("Failed to insert layout child (node may be freed): {}", e);
             }
@@ -723,7 +725,9 @@ impl Engine {
             if let Some(err) = res.err() {
                 error!("Failed to mark layout dirty: {}", err);
             }
-        })) {
+        }))
+        .is_err()
+        {
             error!("layout_prepend_layer panicked (likely invalid layout node)");
         }
     }
@@ -1568,11 +1572,13 @@ impl Engine {
     }
     pub fn set_node_layout_style(&self, node: taffy::NodeId, style: Style) {
         let mut layout = self.layout_tree.write().unwrap();
-        if let Err(_) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        if std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             if let Err(e) = layout.set_style(node, style) {
                 error!("Failed to set layout style (node may be freed): {}", e);
             }
-        })) {
+        }))
+        .is_err()
+        {
             error!("set_node_layout_style panicked (likely invalid layout node)");
         }
     }

--- a/src/engine/scene.rs
+++ b/src/engine/scene.rs
@@ -12,6 +12,7 @@ use crate::{
 use indextree::Arena;
 use serde::Serialize;
 use std::sync::{Arc, RwLock};
+use tracing::error;
 
 use super::{
     node::{RenderableFlags, SceneNode, SceneNodeRenderable},
@@ -22,9 +23,13 @@ use super::{
 impl Engine {
     pub fn set_node_flags(&self, node: NodeRef, flags: RenderableFlags) {
         self.scene.with_arena_mut(|arena| {
-            let node = arena.get_mut(node.0).unwrap();
-            let scene_node = node.get_mut();
-            scene_node.insert_flags(flags);
+            if let Err(_) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                if let Some(node) = arena.get_mut(node.0) {
+                    node.get_mut().insert_flags(flags);
+                }
+            })) {
+                error!("set_node_flags: panicked on freed node");
+            }
         });
     }
 }
@@ -181,8 +186,7 @@ impl Scene {
 
     pub fn with_arena<T: Send + Sync>(&self, f: impl FnOnce(&Arena<SceneNode>) -> T) -> T {
         let arena_guard = self.nodes.data();
-
-        let arena = arena_guard.read().unwrap();
+        let arena = arena_guard.read().unwrap_or_else(|e| e.into_inner());
         f(&arena)
     }
 
@@ -196,10 +200,16 @@ impl Scene {
         Some(f(&arena))
     }
 
-    pub(crate) fn with_arena_mut<T>(&self, f: impl FnOnce(&mut Arena<SceneNode>) -> T) -> T {
+    pub(crate) fn with_arena_mut<T: Default>(&self, f: impl FnOnce(&mut Arena<SceneNode>) -> T) -> T {
         let arena_guard = self.nodes.data();
-        let mut arena = arena_guard.write().unwrap();
-        f(&mut arena)
+        let mut arena = arena_guard.write().unwrap_or_else(|e| e.into_inner());
+        match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| f(&mut arena))) {
+            Ok(result) => result,
+            Err(_) => {
+                tracing::error!("with_arena_mut: closure panicked (likely freed node)");
+                T::default()
+            }
+        }
     }
 
     /// Try to run `f` with a write guard; returns `None` if the lock is contended.

--- a/src/engine/scene.rs
+++ b/src/engine/scene.rs
@@ -200,7 +200,10 @@ impl Scene {
         Some(f(&arena))
     }
 
-    pub(crate) fn with_arena_mut<T: Default>(&self, f: impl FnOnce(&mut Arena<SceneNode>) -> T) -> T {
+    pub(crate) fn with_arena_mut<T: Default>(
+        &self,
+        f: impl FnOnce(&mut Arena<SceneNode>) -> T,
+    ) -> T {
         let arena_guard = self.nodes.data();
         let mut arena = arena_guard.write().unwrap_or_else(|e| e.into_inner());
         match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| f(&mut arena))) {

--- a/src/engine/scene.rs
+++ b/src/engine/scene.rs
@@ -23,11 +23,13 @@ use super::{
 impl Engine {
     pub fn set_node_flags(&self, node: NodeRef, flags: RenderableFlags) {
         self.scene.with_arena_mut(|arena| {
-            if let Err(_) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            if std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 if let Some(node) = arena.get_mut(node.0) {
                     node.get_mut().insert_flags(flags);
                 }
-            })) {
+            }))
+            .is_err()
+            {
                 error!("set_node_flags: panicked on freed node");
             }
         });

--- a/src/engine/stages/update_node.rs
+++ b/src/engine/stages/update_node.rs
@@ -41,8 +41,24 @@ pub(crate) fn update_node_single(
     parent: Option<&RenderLayer>,
     parent_changed: bool,
 ) -> NodeUpdateResult {
-    let layer = engine.get_layer(&NodeRef(node_id)).unwrap();
-    let node_layout = layout_tree.layout(layer.layout_id).unwrap();
+    let Some(layer) = engine.get_layer(&NodeRef(node_id)) else {
+        return NodeUpdateResult {
+            damage: skia::Rect::default(),
+            propagate_to_children: false,
+        };
+    };
+    let node_layout = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        layout_tree.layout(layer.layout_id).cloned()
+    })) {
+        Ok(Ok(layout)) => layout,
+        Ok(Err(_)) | Err(_) => {
+            tracing::error!("update_node_single: failed to get layout (likely invalid node)");
+            return NodeUpdateResult {
+                damage: skia::Rect::default(),
+                propagate_to_children: false,
+            };
+        }
+    };
 
     // First, read the previous state for comparisons
     let (
@@ -130,7 +146,7 @@ pub(crate) fn update_node_single(
             .map(|node| {
                 let scene_node = node.get_mut();
                 let changed = scene_node.update_render_layer_if_needed(
-                    node_layout,
+                    &node_layout,
                     layer.model.clone(),
                     cumulative_transform,
                     context_opacity,

--- a/src/engine/stages/update_node.rs
+++ b/src/engine/stages/update_node.rs
@@ -52,7 +52,7 @@ pub(crate) fn update_node_single(
     })) {
         Ok(Ok(layout)) => layout,
         Ok(Err(_)) | Err(_) => {
-            tracing::error!("update_node_single: failed to get layout (likely invalid node)");
+            tracing::debug!("update_node_single: failed to get layout (likely invalid node)");
             return NodeUpdateResult {
                 damage: skia::Rect::default(),
                 propagate_to_children: false,

--- a/src/layers/layer/mod.rs
+++ b/src/layers/layer/mod.rs
@@ -283,7 +283,7 @@ impl Layer {
         let value_id = self.model.size.id;
 
         let change: Arc<ModelChange<Size>> = Arc::new(ModelChange {
-            value_change: self.model.size.to(value.clone(), transition),
+            value_change: self.model.size.to(value, transition),
             flag: flags,
         });
 

--- a/src/layers/layer/mod.rs
+++ b/src/layers/layer/mod.rs
@@ -115,9 +115,8 @@ impl Layer {
             if let Some(parent_id) = iter.next() {
                 if let Some(parent_node) = arena.get_mut(parent_id).filter(|n| !n.is_removed()) {
                     let parent = parent_node.get_mut();
-                    parent.insert_flags(
-                        RenderableFlags::NEEDS_LAYOUT | RenderableFlags::NEEDS_PAINT,
-                    );
+                    parent
+                        .insert_flags(RenderableFlags::NEEDS_LAYOUT | RenderableFlags::NEEDS_PAINT);
                 }
             }
         });
@@ -204,7 +203,11 @@ impl Layer {
         }
 
         let layout_size = {
-            let layout_tree = self.engine.layout_tree.read().unwrap_or_else(|e| e.into_inner());
+            let layout_tree = self
+                .engine
+                .layout_tree
+                .read()
+                .unwrap_or_else(|e| e.into_inner());
             let layout = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 layout_tree.layout(self.layout_id).cloned()
             })) {
@@ -514,7 +517,11 @@ impl Layer {
             arena
                 .get(self.id.into())
                 .filter(|n| !n.is_removed())
-                .map(|node| node.get().render_layer.global_transformed_bounds_with_children)
+                .map(|node| {
+                    node.get()
+                        .render_layer
+                        .global_transformed_bounds_with_children
+                })
                 .unwrap_or_else(skia_safe::Rect::new_empty)
         })
     }

--- a/src/layers/layer/mod.rs
+++ b/src/layers/layer/mod.rs
@@ -204,10 +204,13 @@ impl Layer {
         }
 
         let layout_size = {
-            let layout_tree = self.engine.layout_tree.read().unwrap();
-            let layout = layout_tree
-                .layout(self.layout_id)
-                .expect("layout is available for every layer");
+            let layout_tree = self.engine.layout_tree.read().unwrap_or_else(|e| e.into_inner());
+            let layout = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                layout_tree.layout(self.layout_id).cloned()
+            })) {
+                Ok(Ok(l)) => l,
+                _ => return self.position(),
+            };
             layout.size
         };
 

--- a/src/layers/layer/mod.rs
+++ b/src/layers/layer/mod.rs
@@ -89,6 +89,7 @@ impl Layer {
         if self.hidden() == hidden {
             return;
         }
+
         // when hidden we set display to none so that the layout engine
         // doesn't layout the node
         let mut display = Display::None;
@@ -104,23 +105,19 @@ impl Layer {
 
         self.engine.scene.with_arena_mut(|arena| {
             let id = self.id.into();
-            let node = arena.get_mut(id);
-            if let Some(node) = node {
+            if let Some(node) = arena.get_mut(id).filter(|n| !n.is_removed()) {
                 let node = node.get_mut();
-
                 node.set_hidden(hidden);
                 node.insert_flags(RenderableFlags::NEEDS_LAYOUT | RenderableFlags::NEEDS_PAINT);
             }
             let mut iter = id.ancestors(arena);
             iter.next(); // skip self
             if let Some(parent_id) = iter.next() {
-                if arena.get(parent_id).is_some() {
-                    if let Some(parent_node) = arena.get_mut(parent_id) {
-                        let parent = parent_node.get_mut();
-                        parent.insert_flags(
-                            RenderableFlags::NEEDS_LAYOUT | RenderableFlags::NEEDS_PAINT,
-                        );
-                    }
+                if let Some(parent_node) = arena.get_mut(parent_id).filter(|n| !n.is_removed()) {
+                    let parent = parent_node.get_mut();
+                    parent.insert_flags(
+                        RenderableFlags::NEEDS_LAYOUT | RenderableFlags::NEEDS_PAINT,
+                    );
                 }
             }
         });
@@ -129,9 +126,10 @@ impl Layer {
     }
     pub fn hidden(&self) -> bool {
         self.engine.scene.with_arena(|a| {
-            let node = a.get(self.id.into()).unwrap();
-            let node = node.get();
-            node.hidden
+            a.get(self.id.into())
+                .filter(|n| !n.is_removed())
+                .map(|node| node.get().hidden)
+                .unwrap_or(false)
         })
     }
     pub fn set_pointer_events(&self, pointer_events: bool) {
@@ -447,74 +445,83 @@ impl Layer {
     }
     pub fn render_layer(&self) -> RenderLayer {
         self.engine.scene.with_arena(|arena| {
-            let node = arena.get(self.id.0).unwrap();
-            let node = node.get();
-            node.render_layer.clone()
+            arena
+                .get(self.id.0)
+                .filter(|n| !n.is_removed())
+                .map(|node| node.get().render_layer.clone())
+                .unwrap_or_default()
         })
     }
     pub fn render_position(&self) -> Point {
         self.engine.scene.with_arena(|arena| {
-            let node = arena.get(self.id.into()).unwrap();
-            let node = node.get();
-            let render_layer = &node.render_layer;
-            let rl = render_layer;
-            Point {
-                x: rl.global_transformed_bounds.x(),
-                y: rl.global_transformed_bounds.y(),
-            }
+            arena
+                .get(self.id.into())
+                .filter(|n| !n.is_removed())
+                .map(|node| {
+                    let rl = &node.get().render_layer;
+                    Point {
+                        x: rl.global_transformed_bounds.x(),
+                        y: rl.global_transformed_bounds.y(),
+                    }
+                })
+                .unwrap_or(Point { x: 0.0, y: 0.0 })
         })
     }
     pub fn render_size_transformed(&self) -> Point {
         self.engine.scene.with_arena(|arena| {
-            let node = arena.get(self.id.into()).unwrap();
-            let node = node.get();
-            let render_layer = &node.render_layer;
-            let rl = render_layer;
-            Point {
-                x: rl.global_transformed_bounds.width(),
-                y: rl.global_transformed_bounds.height(),
-            }
+            arena
+                .get(self.id.into())
+                .filter(|n| !n.is_removed())
+                .map(|node| {
+                    let rl = &node.get().render_layer;
+                    Point {
+                        x: rl.global_transformed_bounds.width(),
+                        y: rl.global_transformed_bounds.height(),
+                    }
+                })
+                .unwrap_or(Point { x: 0.0, y: 0.0 })
         })
     }
     pub fn render_size(&self) -> Point {
         self.engine.scene.with_arena(|arena| {
-            let Some(node) = arena.get(self.id.into()) else {
-                return Point { x: 0.0, y: 0.0 };
-            };
-            let node = node.get();
-            let render_layer = &node.render_layer;
-            let rl = render_layer;
-            Point {
-                x: rl.bounds.width(),
-                y: rl.bounds.height(),
-            }
+            arena
+                .get(self.id.into())
+                .filter(|n| !n.is_removed())
+                .map(|node| {
+                    let rl = &node.get().render_layer;
+                    Point {
+                        x: rl.bounds.width(),
+                        y: rl.bounds.height(),
+                    }
+                })
+                .unwrap_or(Point { x: 0.0, y: 0.0 })
         })
     }
     pub fn render_bounds_transformed(&self) -> skia_safe::Rect {
         self.engine.scene.with_arena(|arena| {
-            let node = arena.get(self.id.into()).unwrap();
-            let node = node.get();
-            let render_layer = &node.render_layer;
-            let rl = render_layer;
-            rl.global_transformed_bounds
+            arena
+                .get(self.id.into())
+                .filter(|n| !n.is_removed())
+                .map(|node| node.get().render_layer.global_transformed_bounds)
+                .unwrap_or_else(skia_safe::Rect::new_empty)
         })
     }
     pub fn render_bounds_with_children_transformed(&self) -> skia_safe::Rect {
         self.engine.scene.with_arena(|arena| {
-            let node = arena.get(self.id.into()).unwrap();
-            let node = node.get();
-            let render_layer = &node.render_layer;
-            let rl = render_layer;
-            rl.global_transformed_bounds_with_children
+            arena
+                .get(self.id.into())
+                .filter(|n| !n.is_removed())
+                .map(|node| node.get().render_layer.global_transformed_bounds_with_children)
+                .unwrap_or_else(skia_safe::Rect::new_empty)
         })
     }
     pub fn render_bounds_with_children(&self) -> skia_safe::Rect {
         self.engine.scene.with_arena(|arena| {
-            let node = arena.get(self.id.into()).unwrap();
-            let node = node.get();
-            let render_layer = &node.render_layer;
-            let rl = render_layer;
-            rl.bounds_with_children
+            arena
+                .get(self.id.into())
+                .filter(|n| !n.is_removed())
+                .map(|node| node.get().render_layer.bounds_with_children)
+                .unwrap_or_else(skia_safe::Rect::new_empty)
         })
     }
     pub fn cointains_point(&self, point: impl Into<skia_safe::Point>) -> bool {
@@ -650,19 +657,17 @@ impl Layer {
     }
     pub fn set_image_cached(&self, image_cached: bool) {
         self.engine.scene.with_arena_mut(|arena| {
-            let id = self.id.0;
-            let node = arena.get_mut(id).unwrap();
-            let node = node.get_mut();
-            node.set_image_cached(image_cached);
+            if let Some(node) = arena.get_mut(self.id.0).filter(|n| !n.is_removed()) {
+                node.get_mut().set_image_cached(image_cached);
+            }
         });
     }
 
     pub fn set_picture_cached(&self, picture_cache: bool) {
         self.engine.scene.with_arena_mut(|arena| {
-            let id = self.id.0;
-            let node = arena.get_mut(id).unwrap();
-            let node = node.get_mut();
-            node.set_picture_cached(picture_cache);
+            if let Some(node) = arena.get_mut(self.id.0).filter(|n| !n.is_removed()) {
+                node.get_mut().set_picture_cached(picture_cache);
+            }
         });
         if !picture_cache {
             self.engine.scene.with_renderable_arena_mut(|arena| {
@@ -676,10 +681,8 @@ impl Layer {
     pub fn add_follower_node(&self, follower: impl Into<NodeRef>) {
         let follower = follower.into();
         self.engine.scene.with_arena_mut(|node_arena| {
-            let node = node_arena.get_mut(self.id.0);
-            if let Some(node) = node {
-                let scene_node = node.get_mut();
-                scene_node.followers.insert(follower);
+            if let Some(node) = node_arena.get_mut(self.id.0).filter(|n| !n.is_removed()) {
+                node.get_mut().followers.insert(follower);
             }
         });
         let attribute_id = self.model.blend_mode.id;
@@ -689,10 +692,8 @@ impl Layer {
     pub fn remove_follower_node(&self, follower: impl Into<NodeRef>) {
         let follower = follower.into();
         self.engine.scene.with_arena_mut(|node_arena| {
-            let node = node_arena.get_mut(self.id.0);
-            if let Some(node) = node {
-                let scene_node = node.get_mut();
-                scene_node.followers.remove(&follower);
+            if let Some(node) = node_arena.get_mut(self.id.0).filter(|n| !n.is_removed()) {
+                node.get_mut().followers.remove(&follower);
             }
         });
     }
@@ -724,8 +725,7 @@ impl Layer {
                         if scene_node.is_removed() {
                             return skia::Rect::from_xywh(0.0, 0.0, w, h);
                         }
-                        let scene_node = scene_node.get();
-                        let render_layer = &scene_node.render_layer;
+                        let render_layer = &scene_node.get().render_layer;
                         let damage = render_layer.bounds_with_children;
                         return damage;
                     }

--- a/tests/engine.rs
+++ b/tests/engine.rs
@@ -1,6 +1,26 @@
 use layers::{prelude::*, types::Size};
 
 #[test]
+pub fn pending_transactions_count_reflects_scheduled_changes() {
+    let engine = Engine::create(1000.0, 1000.0);
+
+    let layer = engine.new_layer();
+    engine.add_layer(&layer);
+
+    // Before any change is scheduled there should be no pending transactions.
+    engine.update(0.016);
+    assert_eq!(engine.pending_transactions_count(), 0);
+
+    // Scheduling a property change enqueues at least one transaction.
+    layer.set_size(Size::points(200.0, 200.0), None);
+    assert!(engine.pending_transactions_count() > 0);
+
+    // After update processes the queue the count returns to zero.
+    engine.update(0.016);
+    assert_eq!(engine.pending_transactions_count(), 0);
+}
+
+#[test]
 pub fn engine_update() {
     let engine = Engine::create(1000.0, 1000.0);
 

--- a/tests/engine.rs
+++ b/tests/engine.rs
@@ -136,9 +136,9 @@ pub fn access_removed_node_does_not_panic() {
     engine.update(0.016);
 
     // Access the arena with the stale node id — must not panic
-    let result = engine.scene().with_arena(|arena| {
-        arena.get(node_id).map(|node| node.is_removed())
-    });
+    let result = engine
+        .scene()
+        .with_arena(|arena| arena.get(node_id).map(|node| node.is_removed()));
 
     // Node slot still exists but is marked as removed
     assert_eq!(result, Some(true));

--- a/tests/engine.rs
+++ b/tests/engine.rs
@@ -112,3 +112,37 @@ fn removing_layer_subtree_triggers_layout() {
     // The panic is triggered during cleanup inside this update.
     engine.update(0.016);
 }
+
+#[test]
+pub fn access_removed_node_does_not_panic() {
+    let engine = Engine::create(1000.0, 1000.0);
+
+    let root = engine.new_layer();
+    root.set_size(Size::points(500.0, 500.0), None);
+    engine.add_layer(&root);
+
+    let child = engine.new_layer();
+    child.set_size(Size::points(100.0, 100.0), None);
+    root.add_sublayer(&child);
+
+    engine.update(0.016);
+
+    // Grab the node id while it's still alive
+    let node_ref = child.id();
+    let node_id: indextree::NodeId = node_ref.into();
+
+    // Remove the layer and process the removal
+    child.remove();
+    engine.update(0.016);
+
+    // Access the arena with the stale node id — must not panic
+    let result = engine.scene().with_arena(|arena| {
+        arena.get(node_id).map(|node| node.is_removed())
+    });
+
+    // Node slot still exists but is marked as removed
+    assert_eq!(result, Some(true));
+
+    // render_layer should return None for a removed node
+    assert!(engine.render_layer(&node_ref).is_none());
+}


### PR DESCRIPTION
## Summary

This PR improves robustness of arena node access and adds a new API:

- **Safe arena node access**: Replace unsafe accesses with `is_removed` checks to avoid panics on freed nodes
- **Wrap layout and arena operations in `catch_unwind`**: Prevent panics from propagating when nodes are freed during layout
- **Add `pending_transactions_count` API**: New method to query the number of pending transactions
- **Fix clippy warnings** in engine and layer mod