### PR TITLE
feat: add IntoFuture for AnimationRef

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -441,22 +441,19 @@ impl AnimationRef {
 
     /// Add a callback that is triggered when the animation is started.
     pub fn on_start<F: Into<AnimationCallback>>(&self, handler: F, once: bool) -> &Self {
-        self.engine()
-            .on_animation_start(*self, handler, once);
+        self.engine().on_animation_start(*self, handler, once);
         self
     }
 
     /// Add a callback that is triggered when the animation is updated.
     pub fn on_update<F: Into<AnimationCallback>>(&self, handler: F, once: bool) -> &Self {
-        self.engine()
-            .on_animation_update(*self, handler, once);
+        self.engine().on_animation_update(*self, handler, once);
         self
     }
 
     /// Add a callback that is triggered when the animation is finished.
     pub fn on_finish<F: Into<AnimationCallback>>(&self, handler: F, once: bool) -> &Self {
-        self.engine()
-            .on_animation_finish(*self, handler, once);
+        self.engine().on_animation_finish(*self, handler, once);
         self
     }
 }
@@ -1046,7 +1043,10 @@ impl Engine {
             is_finished: false,
             is_started: false,
         });
-        AnimationRef { id: aid, engine_id: self.id }
+        AnimationRef {
+            id: aid,
+            engine_id: self.id,
+        }
     }
     pub fn start_animation(&self, animation: AnimationRef, delay: f32) {
         self.animations.with_data_mut(|animations| {

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -37,6 +37,7 @@ pub(crate) mod scene;
 pub mod animation;
 pub(crate) mod node;
 pub(crate) mod storage;
+pub mod task;
 
 use core::fmt;
 
@@ -425,49 +426,44 @@ impl TransactionRef {
 }
 
 #[derive(Clone, Copy, Debug)]
-pub struct AnimationRef(FlatStorageId);
+pub struct AnimationRef {
+    pub(crate) id: FlatStorageId,
+    pub(crate) engine_id: usize,
+}
 
+#[allow(static_mut_refs)]
 impl AnimationRef {
-    fn engine(&self) -> Arc<Engine> {
-        // We need to get the engine from somewhere
-        // Since AnimationRef doesn't store engine_id, we'll need to add it
-        // For now, we'll just implement the methods on Engine and expose them differently
-        unimplemented!("Use engine methods directly")
+    pub(crate) fn engine(&self) -> Arc<Engine> {
+        ENGINE_REGISTRY
+            .get(self.engine_id)
+            .expect("no engine found")
     }
 
     /// Add a callback that is triggered when the animation is started.
-    ///
-    /// # Arguments
-    /// * `handler`: the callback function to be called
-    /// * `once`: if true, the callback is removed after it is triggered
-    pub fn on_start<F: Into<TransactionCallback>>(&self, _handler: F, _once: bool) -> &Self {
-        // Implementation note: Since AnimationRef doesn't have engine reference,
-        // users should call engine.on_animation_start(animation, handler, once) instead
-        unimplemented!("Use Engine::on_animation_start instead")
+    pub fn on_start<F: Into<AnimationCallback>>(&self, handler: F, once: bool) -> &Self {
+        self.engine()
+            .on_animation_start(*self, handler, once);
+        self
     }
 
     /// Add a callback that is triggered when the animation is updated.
-    ///
-    /// # Arguments
-    /// * `handler`: the callback function to be called
-    /// * `once`: if true, the callback is removed after it is triggered
-    pub fn on_update<F: Into<TransactionCallback>>(&self, _handler: F, _once: bool) -> &Self {
-        unimplemented!("Use Engine::on_animation_update instead")
+    pub fn on_update<F: Into<AnimationCallback>>(&self, handler: F, once: bool) -> &Self {
+        self.engine()
+            .on_animation_update(*self, handler, once);
+        self
     }
 
     /// Add a callback that is triggered when the animation is finished.
-    ///
-    /// # Arguments
-    /// * `handler`: the callback function to be called
-    /// * `once`: if true, the callback is removed after it is triggered
-    pub fn on_finish<F: Into<TransactionCallback>>(&self, _handler: F, _once: bool) -> &Self {
-        unimplemented!("Use Engine::on_animation_finish instead")
+    pub fn on_finish<F: Into<AnimationCallback>>(&self, handler: F, once: bool) -> &Self {
+        self.engine()
+            .on_animation_finish(*self, handler, once);
+        self
     }
 }
 
 impl std::fmt::Display for AnimationRef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "AnimationRef({})", self.0)
+        write!(f, "AnimationRef({})", self.id)
     }
 }
 /// An identifier for a node in the three storage
@@ -1050,11 +1046,11 @@ impl Engine {
             is_finished: false,
             is_started: false,
         });
-        AnimationRef(aid)
+        AnimationRef { id: aid, engine_id: self.id }
     }
     pub fn start_animation(&self, animation: AnimationRef, delay: f32) {
         self.animations.with_data_mut(|animations| {
-            if let Some(animation_state) = animations.get_mut(&animation.0) {
+            if let Some(animation_state) = animations.get_mut(&animation.id) {
                 animation_state.animation.start = self.timestamp.read().unwrap().0 + delay;
                 animation_state.is_running = true;
                 animation_state.is_finished = false;
@@ -1075,7 +1071,7 @@ impl Engine {
         tid.and_then(|id| self.transactions.with_data(|d| d.get(&id).cloned()))
     }
     pub fn get_animation(&self, animation: AnimationRef) -> Option<AnimationState> {
-        self.animations.with_data(|d| d.get(&animation.0).cloned())
+        self.animations.with_data(|d| d.get(&animation.id).cloned())
     }
     pub fn schedule_change(
         &self,
@@ -1145,7 +1141,7 @@ impl Engine {
     }
     pub fn cancel_animation(&self, animation: AnimationRef) {
         self.animations.with_data_mut(|d| {
-            d.remove(&animation.0);
+            d.remove(&animation.id);
         });
     }
     pub fn cancel_transaction(&self, transaction: TransactionRef) {
@@ -1823,7 +1819,7 @@ impl Engine {
     ) {
         let mut handler = handler.into();
         handler.once = once;
-        self.add_animation_handler(animation.0, TransactionEventType::Start, handler);
+        self.add_animation_handler(animation.id, TransactionEventType::Start, handler);
     }
 
     pub fn on_animation_update<F: Into<AnimationCallback>>(
@@ -1834,7 +1830,7 @@ impl Engine {
     ) {
         let mut handler = handler.into();
         handler.once = once;
-        self.add_animation_handler(animation.0, TransactionEventType::Update, handler);
+        self.add_animation_handler(animation.id, TransactionEventType::Update, handler);
     }
 
     pub fn on_animation_finish<F: Into<AnimationCallback>>(
@@ -1845,7 +1841,7 @@ impl Engine {
     ) {
         let mut handler = handler.into();
         handler.once = once;
-        self.add_animation_handler(animation.0, TransactionEventType::Finish, handler);
+        self.add_animation_handler(animation.id, TransactionEventType::Finish, handler);
     }
     #[allow(clippy::unwrap_or_default)]
     pub(crate) fn add_pointer_handler<F: Into<PointerHandlerFunction>>(

--- a/src/engine/stages/mod.rs
+++ b/src/engine/stages/mod.rs
@@ -102,7 +102,7 @@ pub(crate) fn execute_transactions(engine: &Engine) -> (Vec<NodeRef>, Vec<FlatSt
                     let animation_state = command
                         .animation_id
                         .as_ref()
-                        .and_then(|id| animations.get(&id.0).cloned())
+                        .and_then(|id| animations.get(&id.id).cloned())
                         .unwrap_or(AnimationState {
                             animation: Default::default(),
                             progress: 1.0,
@@ -276,7 +276,7 @@ pub(crate) fn trigger_callbacks(engine: &Engine, started_animations: &[FlatStora
             let animation_state = command
                 .animation_id
                 .as_ref()
-                .and_then(|animation_id| engine.animations.get(&animation_id.0))
+                .and_then(|animation_id| engine.animations.get(&animation_id.id))
                 .unwrap_or(AnimationState {
                     animation: Default::default(),
                     progress: 1.0,
@@ -291,7 +291,7 @@ pub(crate) fn trigger_callbacks(engine: &Engine, started_animations: &[FlatStora
 
                 let started = command
                     .animation_id
-                    .map(|a| started_animations.contains(&a.0))
+                    .map(|a| started_animations.contains(&a.id))
                     .unwrap_or(false);
                 let vcallbacks = { engine.value_handlers.get(&command.change.value_id()) };
                 let (tcallback_to_remove, vcallback_to_remove) = transaction_callbacks(

--- a/src/engine/task.rs
+++ b/src/engine/task.rs
@@ -57,16 +57,15 @@ impl Future for TransitionFuture {
         // Register the on_finish callback exactly once.
         if !self.registered {
             let state = Arc::clone(&self.state);
-            self.transaction_ref
-                .on_finish(
-                    move |_layer: &Layer, _| {
-                        state.finished.store(true, Ordering::Release);
-                        if let Some(waker) = state.waker.lock().unwrap().take() {
-                            waker.wake();
-                        }
-                    },
-                    true,
-                );
+            self.transaction_ref.on_finish(
+                move |_layer: &Layer, _| {
+                    state.finished.store(true, Ordering::Release);
+                    if let Some(waker) = state.waker.lock().unwrap().take() {
+                        waker.wake();
+                    }
+                },
+                true,
+            );
             self.registered = true;
         }
 
@@ -149,4 +148,3 @@ impl std::future::IntoFuture for AnimationRef {
         }
     }
 }
-

--- a/src/engine/task.rs
+++ b/src/engine/task.rs
@@ -40,13 +40,12 @@ struct TransitionFutureState {
 pub struct TransitionFuture {
     state: Arc<TransitionFutureState>,
     transaction_ref: TransactionRef,
-    registered: bool,
 }
 
 impl Future for TransitionFuture {
     type Output = ();
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         if self.state.finished.load(Ordering::Acquire) {
             return Poll::Ready(());
         }
@@ -54,19 +53,22 @@ impl Future for TransitionFuture {
         // Keep the waker fresh in case the executor changed.
         *self.state.waker.lock().unwrap() = Some(cx.waker().clone());
 
-        // Register the on_finish callback exactly once.
-        if !self.registered {
-            let state = Arc::clone(&self.state);
-            self.transaction_ref.on_finish(
-                move |_layer: &Layer, _| {
-                    state.finished.store(true, Ordering::Release);
-                    if let Some(waker) = state.waker.lock().unwrap().take() {
-                        waker.wake();
-                    }
-                },
-                true,
-            );
-            self.registered = true;
+        // Re-check after storing the waker: the on_finish callback may have fired
+        // in the window between the first check and now and found no waker to call.
+        if self.state.finished.load(Ordering::Acquire) {
+            return Poll::Ready(());
+        }
+
+        // Defensive check: the transaction may have been cleaned up before
+        // into_future() was called (stale TransactionRef), in which case the
+        // eagerly-registered callback will never fire. Resolve immediately.
+        if self
+            .transaction_ref
+            .engine()
+            .get_transaction(self.transaction_ref)
+            .is_none()
+        {
+            return Poll::Ready(());
         }
 
         Poll::Pending
@@ -78,13 +80,26 @@ impl std::future::IntoFuture for TransactionRef {
     type IntoFuture = TransitionFuture;
 
     fn into_future(self) -> TransitionFuture {
+        let state = Arc::new(TransitionFutureState {
+            finished: AtomicBool::new(false),
+            waker: Mutex::new(None),
+        });
+        // Register the on_finish callback eagerly so that a completion that
+        // occurs between into_future() and the first poll() sets `finished`
+        // before poll() runs, allowing it to return Ready immediately.
+        let state_clone = Arc::clone(&state);
+        self.on_finish(
+            move |_layer: &Layer, _| {
+                state_clone.finished.store(true, Ordering::Release);
+                if let Some(waker) = state_clone.waker.lock().unwrap().take() {
+                    waker.wake();
+                }
+            },
+            true,
+        );
         TransitionFuture {
-            state: Arc::new(TransitionFutureState {
-                finished: AtomicBool::new(false),
-                waker: Mutex::new(None),
-            }),
+            state,
             transaction_ref: self,
-            registered: false,
         }
     }
 }
@@ -100,13 +115,12 @@ impl std::future::IntoFuture for TransactionRef {
 pub struct AnimationFuture {
     state: Arc<TransitionFutureState>,
     animation_ref: AnimationRef,
-    registered: bool,
 }
 
 impl Future for AnimationFuture {
     type Output = ();
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         if self.state.finished.load(Ordering::Acquire) {
             return Poll::Ready(());
         }
@@ -114,19 +128,22 @@ impl Future for AnimationFuture {
         // Keep the waker fresh in case the executor changed.
         *self.state.waker.lock().unwrap() = Some(cx.waker().clone());
 
-        // Register the on_finish callback exactly once.
-        if !self.registered {
-            let state = Arc::clone(&self.state);
-            self.animation_ref.on_finish(
-                move |_progress: f32| {
-                    state.finished.store(true, Ordering::Release);
-                    if let Some(waker) = state.waker.lock().unwrap().take() {
-                        waker.wake();
-                    }
-                },
-                true,
-            );
-            self.registered = true;
+        // Re-check after storing the waker: the on_finish callback may have fired
+        // in the window between the first check and now and found no waker to call.
+        if self.state.finished.load(Ordering::Acquire) {
+            return Poll::Ready(());
+        }
+
+        // Defensive check: the animation may have been cleaned up before
+        // into_future() was called (stale AnimationRef), in which case the
+        // eagerly-registered callback will never fire. Resolve immediately.
+        if self
+            .animation_ref
+            .engine()
+            .get_animation(self.animation_ref)
+            .is_none()
+        {
+            return Poll::Ready(());
         }
 
         Poll::Pending
@@ -138,13 +155,26 @@ impl std::future::IntoFuture for AnimationRef {
     type IntoFuture = AnimationFuture;
 
     fn into_future(self) -> AnimationFuture {
+        let state = Arc::new(TransitionFutureState {
+            finished: AtomicBool::new(false),
+            waker: Mutex::new(None),
+        });
+        // Register the on_finish callback eagerly so that a completion that
+        // occurs between into_future() and the first poll() sets `finished`
+        // before poll() runs, allowing it to return Ready immediately.
+        let state_clone = Arc::clone(&state);
+        self.on_finish(
+            move |_progress: f32| {
+                state_clone.finished.store(true, Ordering::Release);
+                if let Some(waker) = state_clone.waker.lock().unwrap().take() {
+                    waker.wake();
+                }
+            },
+            true,
+        );
         AnimationFuture {
-            state: Arc::new(TransitionFutureState {
-                finished: AtomicBool::new(false),
-                waker: Mutex::new(None),
-            }),
+            state,
             animation_ref: self,
-            registered: false,
         }
     }
 }

--- a/src/engine/task.rs
+++ b/src/engine/task.rs
@@ -1,0 +1,152 @@
+//! Async support for transition sequencing.
+//!
+//! [`TransactionRef`](crate::engine::TransactionRef) implements [`std::future::IntoFuture`],
+//! so every `set_*` call on a [`Layer`](crate::layers::layer::Layer) is directly `await`-able.
+//! Use any async executor — e.g. `tokio::spawn` — to sequence transitions without nested
+//! [`on_finish`](crate::engine::TransactionRef::on_finish) closures:
+//!
+//! ```rust,ignore
+//! tokio::spawn(async move {
+//!     layer.set_position((100.0, 0.0), Transition::ease_in(0.4)).await;
+//!     layer.set_opacity(0.0, Transition::ease_out(0.3)).await;
+//! });
+//! ```
+
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex,
+    },
+    task::{Context, Poll, Waker},
+};
+
+use super::{AnimationRef, TransactionRef};
+use crate::layers::layer::Layer;
+
+struct TransitionFutureState {
+    finished: AtomicBool,
+    waker: Mutex<Option<Waker>>,
+}
+
+/// A future that resolves when a scheduled transition finishes.
+///
+/// Obtain one by `.await`-ing any value returned from a `set_*` method on a [`Layer`]:
+///
+/// ```rust,ignore
+/// layer.set_position((200.0, 0.0), Transition::ease_in(0.5)).await;
+/// ```
+pub struct TransitionFuture {
+    state: Arc<TransitionFutureState>,
+    transaction_ref: TransactionRef,
+    registered: bool,
+}
+
+impl Future for TransitionFuture {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.state.finished.load(Ordering::Acquire) {
+            return Poll::Ready(());
+        }
+
+        // Keep the waker fresh in case the executor changed.
+        *self.state.waker.lock().unwrap() = Some(cx.waker().clone());
+
+        // Register the on_finish callback exactly once.
+        if !self.registered {
+            let state = Arc::clone(&self.state);
+            self.transaction_ref
+                .on_finish(
+                    move |_layer: &Layer, _| {
+                        state.finished.store(true, Ordering::Release);
+                        if let Some(waker) = state.waker.lock().unwrap().take() {
+                            waker.wake();
+                        }
+                    },
+                    true,
+                );
+            self.registered = true;
+        }
+
+        Poll::Pending
+    }
+}
+
+impl std::future::IntoFuture for TransactionRef {
+    type Output = ();
+    type IntoFuture = TransitionFuture;
+
+    fn into_future(self) -> TransitionFuture {
+        TransitionFuture {
+            state: Arc::new(TransitionFutureState {
+                finished: AtomicBool::new(false),
+                waker: Mutex::new(None),
+            }),
+            transaction_ref: self,
+            registered: false,
+        }
+    }
+}
+
+/// A future that resolves when a scheduled animation finishes.
+///
+/// Obtain one by `.await`-ing an [`AnimationRef`]:
+///
+/// ```rust,ignore
+/// let anim = engine.add_animation_from_transition(&transition, true);
+/// anim.await;
+/// ```
+pub struct AnimationFuture {
+    state: Arc<TransitionFutureState>,
+    animation_ref: AnimationRef,
+    registered: bool,
+}
+
+impl Future for AnimationFuture {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.state.finished.load(Ordering::Acquire) {
+            return Poll::Ready(());
+        }
+
+        // Keep the waker fresh in case the executor changed.
+        *self.state.waker.lock().unwrap() = Some(cx.waker().clone());
+
+        // Register the on_finish callback exactly once.
+        if !self.registered {
+            let state = Arc::clone(&self.state);
+            self.animation_ref.on_finish(
+                move |_progress: f32| {
+                    state.finished.store(true, Ordering::Release);
+                    if let Some(waker) = state.waker.lock().unwrap().take() {
+                        waker.wake();
+                    }
+                },
+                true,
+            );
+            self.registered = true;
+        }
+
+        Poll::Pending
+    }
+}
+
+impl std::future::IntoFuture for AnimationRef {
+    type Output = ();
+    type IntoFuture = AnimationFuture;
+
+    fn into_future(self) -> AnimationFuture {
+        AnimationFuture {
+            state: Arc::new(TransitionFutureState {
+                finished: AtomicBool::new(false),
+                waker: Mutex::new(None),
+            }),
+            animation_ref: self,
+            registered: false,
+        }
+    }
+}
+

--- a/src/engine/task.rs
+++ b/src/engine/task.rs
@@ -1,7 +1,7 @@
 //! Async support for transition sequencing.
 //!
-//! [`TransactionRef`](crate::engine::TransactionRef) implements [`std::future::IntoFuture`],
-//! so every `set_*` call on a [`Layer`](crate::layers::layer::Layer) is directly `await`-able.
+//! [`TransactionRef`] implements [`std::future::IntoFuture`],
+//! so every `set_*` call on a [`Layer`] is directly `await`-able.
 //! Use any async executor — e.g. `tokio::spawn` — to sequence transitions without nested
 //! [`on_finish`](crate::engine::TransactionRef::on_finish) closures:
 //!

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -2,7 +2,12 @@ pub use super::drawing::scene::{draw_scene, render_node_tree};
 pub use super::{
     drawing::scene::DrawScene,
     easing::Interpolate,
-    engine::{animation::*, scene::Scene, task::{AnimationFuture, TransitionFuture}, AnimationRef, Engine, NodeRef, TransactionRef},
+    engine::{
+        animation::*,
+        scene::Scene,
+        task::{AnimationFuture, TransitionFuture},
+        AnimationRef, Engine, NodeRef, TransactionRef,
+    },
     layers::{
         layer::model::{ContentDrawError, ContentDrawFunction, PointerHandlerFunction},
         layer::Effect,

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -2,7 +2,7 @@ pub use super::drawing::scene::{draw_scene, render_node_tree};
 pub use super::{
     drawing::scene::DrawScene,
     easing::Interpolate,
-    engine::{animation::*, scene::Scene, Engine, NodeRef},
+    engine::{animation::*, scene::Scene, task::{AnimationFuture, TransitionFuture}, AnimationRef, Engine, NodeRef, TransactionRef},
     layers::{
         layer::model::{ContentDrawError, ContentDrawFunction, PointerHandlerFunction},
         layer::Effect,

--- a/tests/transaction_handler.rs
+++ b/tests/transaction_handler.rs
@@ -1,5 +1,24 @@
 use layers::prelude::*;
-use std::sync::{Arc, RwLock};
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::{Arc, RwLock},
+    task::{Context, Poll, RawWaker, RawWakerVTable, Waker},
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// A no-op waker for manually driving futures in synchronous tests.
+fn noop_waker() -> Waker {
+    fn noop(_: *const ()) {}
+    fn clone(_: *const ()) -> RawWaker {
+        RawWaker::new(std::ptr::null(), &VTABLE)
+    }
+    static VTABLE: RawWakerVTable = RawWakerVTable::new(clone, noop, noop, noop);
+    unsafe { Waker::from_raw(RawWaker::new(std::ptr::null(), &VTABLE)) }
+}
 
 /// it should call the finish handler when the transaction is finished 1 time
 #[test]
@@ -317,4 +336,64 @@ pub fn call_update_value() {
         let c = called.read().unwrap();
         assert_eq!(*c, 4);
     }
+}
+
+/// TransitionFuture must resolve on the first poll when the transaction was
+/// already completed (and cleaned up) before into_future() was called.
+///
+/// Previously the callback was registered lazily in poll(), so a transaction
+/// that finished before poll() ran would leave the future pending forever.
+#[test]
+pub fn transition_future_resolves_when_transaction_already_done() {
+    let engine = Engine::create(1000.0, 1000.0);
+    let layer = engine.new_layer();
+    engine.add_layer(&layer);
+
+    let transaction =
+        layer.set_position(Point { x: 200.0, y: 100.0 }, Some(Transition::linear(0.1)));
+
+    // Advance past the transition duration so it is completed and cleaned up.
+    engine.update(0.2);
+
+    // Create the future *after* the transaction is gone.
+    let mut future = std::future::IntoFuture::into_future(transaction);
+    let waker = noop_waker();
+    let mut cx = Context::from_waker(&waker);
+
+    // Should resolve on the very first poll, not hang as Pending.
+    let result = Pin::new(&mut future).poll(&mut cx);
+    assert!(
+        matches!(result, Poll::Ready(())),
+        "TransitionFuture should return Poll::Ready on first poll when the transaction is already done"
+    );
+}
+
+/// TransitionFuture must also resolve when the transaction finishes between
+/// into_future() and the first poll() (the callback fires with no waker yet,
+/// but the finished flag is set and poll() sees it).
+#[test]
+pub fn transition_future_resolves_when_transaction_completes_before_poll() {
+    let engine = Engine::create(1000.0, 1000.0);
+    let layer = engine.new_layer();
+    engine.add_layer(&layer);
+
+    let transaction =
+        layer.set_position(Point { x: 200.0, y: 100.0 }, Some(Transition::linear(0.1)));
+
+    // Create the future (registers the callback eagerly) …
+    let mut future = std::future::IntoFuture::into_future(transaction);
+
+    // … then complete the transaction before the first poll.
+    engine.update(0.2);
+
+    let waker = noop_waker();
+    let mut cx = Context::from_waker(&waker);
+
+    // The eagerly-registered callback has fired and set finished=true, so the
+    // first poll should return Ready.
+    let result = Pin::new(&mut future).poll(&mut cx);
+    assert!(
+        matches!(result, Poll::Ready(())),
+        "TransitionFuture should return Poll::Ready on first poll when the transaction finished before poll() ran"
+    );
 }


### PR DESCRIPTION
Add async/await support for AnimationRef and TransactionRef, implementing the trai IntoFuture

- AnimationRef now has engine_id field for ENGINE_REGISTRY lookup
- Implement engine(), on_start(), on_update(), on_finish() methods
- Add AnimationFuture struct and IntoFuture impl for AnimationRef
- Export AnimationFuture and AnimationRef in prelude
