### PR TITLE
Rendering optimizations and error propagation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ paste = "1.0"
 glutin = "0.29"
 winit = "0.28"
 image-compare = "0.4.1"
-image = { version = "0.25", default-features = false, features = ["png"] }
+image = { version = ">=0.25, <0.25.10", default-features = false, features = ["png"] }
 
 [dependencies.layers_inspector]
 path = "packages/debugger_browser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laye-rs"
-version = "1.5.1"
+version = "1.6.0"
 edition = "2021"
 build = "build.rs"
 rust-version = "1.85.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laye-rs"
-version = "1.5.0"
+version = "1.5.1"
 edition = "2021"
 build = "build.rs"
 rust-version = "1.85.0"

--- a/benches/my_benchmark.rs
+++ b/benches/my_benchmark.rs
@@ -20,7 +20,7 @@ fn criterion_benchmark_update(c: &mut Criterion) {
             let mut layers = Vec::<Layer>::new();
             for _ in 0..count {
                 let layer = engine.new_layer();
-                engine.add_layer(&layer.id);
+                engine.add_layer(&layer.id).unwrap();
                 layers.push(layer);
             }
             for layer in layers.iter() {
@@ -52,7 +52,7 @@ fn criterion_benchmark_append(c: &mut Criterion) {
 
             b.iter(|| {
                 let layer = engine.new_layer();
-                engine.add_layer(&layer.id);
+                engine.add_layer(&layer.id).unwrap();
                 engine.update(black_box(0.016));
             });
         });
@@ -74,7 +74,7 @@ fn criterion_benchmark_remove(c: &mut Criterion) {
             let mut layers = Vec::<Layer>::new();
             for _ in 0..count {
                 let layer = engine.new_layer();
-                engine.add_layer(&layer.id);
+                engine.add_layer(&layer.id).unwrap();
                 layers.push(layer);
             }
             engine.update(black_box(0.016));
@@ -115,7 +115,7 @@ fn criterion_benchmark_pointer_move(c: &mut Criterion) {
                     ),
                     None,
                 );
-                engine.add_layer(&layer.id);
+                engine.add_layer(&layer.id).unwrap();
                 layers.push(layer);
             }
             engine.update(black_box(0.016));

--- a/benches/pointer_depth_benchmark.rs
+++ b/benches/pointer_depth_benchmark.rs
@@ -25,7 +25,7 @@ fn create_layer_tree(engine: &Engine, depth: usize) -> (Layer, Vec<Layer>) {
             black_box(&layer_clone);
         });
 
-        engine.append_layer(&child.id, current.id);
+        engine.append_layer(&child.id, current.id).unwrap();
         current = child.clone();
         layers.push(child);
     }
@@ -62,7 +62,7 @@ fn create_wide_layer_tree(engine: &Engine, depth: usize, siblings: usize) -> (La
                     black_box(&layer_clone);
                 });
 
-                engine.append_layer(&child.id, parent.id);
+                engine.append_layer(&child.id, parent.id).unwrap();
                 next_level.push(child.clone());
                 layers.push(child);
             }

--- a/docs/engine-update-stages.md
+++ b/docs/engine-update-stages.md
@@ -58,7 +58,7 @@ Occlusion culling is a **separate step** invoked by the caller after `Engine::up
 
 **API pattern** (per frame):
 
-```rust
+```rust,ignore
 engine.update(dt);
 engine.clear_occlusion();                       // reset all roots
 engine.compute_occlusion(root_a);               // compute for first root

--- a/docs/engine-update-stages.md
+++ b/docs/engine-update-stages.md
@@ -78,7 +78,7 @@ A layer is considered fully opaque when all of these hold:
 
 **Clip-awareness:** When an ancestor has `clip_children = true`, child bounds are intersected with the ancestor's clip region. Children entirely outside the clip are marked occluded (they produce no visible pixels). Opaque layers contribute only the intersection of their bounds with the active clip to the mask, preventing false occlusion of layers that extend beyond the clip boundary.
 
-The occluded set is stored on the `Scene` keyed by root node (`OcclusionMap = HashMap<NodeRef, HashSet<NodeRef>>`), so multiple render passes from different roots each get their own data. During rendering, `render_node_tree` checks the set and skips occluded nodes entirely.
+The occluded set is stored on the `Scene` keyed by root node (`OcclusionMap = HashMap<NodeRef, HashSet<NodeRef>>`), so multiple render passes from different roots each get their own data. During rendering, `render_node_tree` checks the set and skips *painting* occluded nodes (their children are still traversed, because a child may itself be the occluder or have non-occluded descendants). A node qualifies as an occluder when `is_fully_opaque()` returns true, which requires alpha 1.0, no rounded corners, a `RoundRect` shape, **and** `content_opaque` set to true (indicating the node's content fills its bounds without transparency).
 
 ### 5. Rendering
 

--- a/docs/engine-update-stages.md
+++ b/docs/engine-update-stages.md
@@ -12,6 +12,7 @@ Every call to `Engine::update(dt)` executes the same ordered pipeline:
 | 2. Apply transactions  | `execute_transactions`                             | Update `ModelLayer` properties and adjust render/layout flags            |
 | 3. Solve layout        | `update_layout_tree`                               | Run Taffy to recompute node sizes and positions                          |
 | 4. Refresh nodes       | `Engine::update_nodes` (`src/engine/mod.rs`)       | Visit each scene node, update render layers, and calculate damage        |
+| 4b. Occlusion culling  | `Engine::compute_occlusion` (caller-driven)        | Mark nodes fully hidden behind opaque layers so rendering can skip them  |
 | 5. Render              | `render_node_tree` (`src/drawing/scene.rs`)        | Replay cached pictures or draw commands, clipping to accumulated damage  |
 | 6. Cleanup deleted     | `cleanup_nodes` (`src/engine/stages/mod.rs`)       | Drop `SceneNode`s marked for removal and tidy layout bookkeeping safely  |
 
@@ -50,6 +51,34 @@ Returned rectangles are joined into the per-frame damage accumulator. The engine
 - Children rely on the latest parent transform and premultiplied opacity when repainting. Running parents first keeps those values fresh before `update_node_single` executes on the child.
 - Parents still detect child-driven layout changes because they compare their own new layout data (just written by Taffy) against the previous render-layer snapshot. Aggregated child bounds are read from the stored `SceneNode`, so "before" and "after" comparisons remain valid even if the child has not updated yet.
 - When a child runs later in the pass it reports damage in global coordinates. `update_nodes` merges that rectangle into the frame total, so child content changes are preserved even though the parent processed earlier.
+
+### 4b. Occlusion culling (caller-driven)
+
+Occlusion culling is a **separate step** invoked by the caller after `Engine::update`. It is not part of the automatic pipeline because scenes may be rendered from multiple root nodes, and each root needs its own occlusion data.
+
+**API pattern** (per frame):
+
+```rust
+engine.update(dt);
+engine.clear_occlusion();                       // reset all roots
+engine.compute_occlusion(root_a);               // compute for first root
+engine.compute_occlusion(root_b);               // compute for second root
+// ... render ...
+```
+
+`Engine::compute_occlusion(root)` calls `occlusion::compute_occlusion` (`src/engine/occlusion.rs`), which traverses the subtree rooted at `root` in draw order (pre-order, back-to-front) and then iterates in reverse (front-to-back). Fully-opaque rectangular layers contribute their `global_transformed_bounds` (intersected with any active clip) to an occlusion mask. Any node whose visible bounds are fully contained by a mask entry is added to the occluded set.
+
+A layer is considered fully opaque when all of these hold:
+
+- `premultiplied_opacity >= 1.0` (accounts for parent opacity)
+- `blend_mode == Normal` (not `BackgroundBlur`)
+- Background color alpha is 1.0 across all gradient stops
+- No rounded corners (`border_corner_radius` is all zeros)
+- Shape is `RoundRect` (not a custom path)
+
+**Clip-awareness:** When an ancestor has `clip_children = true`, child bounds are intersected with the ancestor's clip region. Children entirely outside the clip are marked occluded (they produce no visible pixels). Opaque layers contribute only the intersection of their bounds with the active clip to the mask, preventing false occlusion of layers that extend beyond the clip boundary.
+
+The occluded set is stored on the `Scene` keyed by root node (`OcclusionMap = HashMap<NodeRef, HashSet<NodeRef>>`), so multiple render passes from different roots each get their own data. During rendering, `render_node_tree` checks the set and skips occluded nodes entirely.
 
 ### 5. Rendering
 

--- a/src/api/engine.rs
+++ b/src/api/engine.rs
@@ -28,7 +28,7 @@ pub extern "C" fn engine_add_layer_to_scene(engine: *const engine::Engine, layer
     let engine = unsafe { &*engine };
     let layer = unsafe { &*layer };
 
-    engine.append_layer(&layer.id, None);
+    let _ = engine.append_layer(&layer.id, None);
 }
 
 #[no_mangle]

--- a/src/api/engine.rs
+++ b/src/api/engine.rs
@@ -28,7 +28,9 @@ pub extern "C" fn engine_add_layer_to_scene(engine: *const engine::Engine, layer
     let engine = unsafe { &*engine };
     let layer = unsafe { &*layer };
 
-    let _ = engine.append_layer(&layer.id, None);
+    if let Err(e) = engine.append_layer(&layer.id, None) {
+        tracing::error!("engine_add_layer_to_scene: failed to add layer: {}", e);
+    }
 }
 
 #[no_mangle]

--- a/src/drawing/scene.rs
+++ b/src/drawing/scene.rs
@@ -114,7 +114,15 @@ pub fn draw_scene(canvas: &skia::Canvas, scene: std::sync::Arc<Scene>, root_id: 
                 let node = root.get();
                 let restore_point = canvas.save();
                 set_node_transform(node, canvas);
-                render_node_tree(root_id, scene_arena, renderables_arena, canvas, 1.0, None, None);
+                render_node_tree(
+                    root_id,
+                    scene_arena,
+                    renderables_arena,
+                    canvas,
+                    1.0,
+                    None,
+                    None,
+                );
                 canvas.restore_to_count(restore_point);
             }
         });

--- a/src/drawing/scene.rs
+++ b/src/drawing/scene.rs
@@ -4,6 +4,7 @@ use indextree::{Arena, NodeId};
 use skia::{gpu::ganesh::gl::direct_contexts, FontStyle, Surface};
 use skia_safe::Canvas;
 use skia_safe::Contains;
+use skia_safe::RoundOut;
 
 use crate::{
     engine::{
@@ -19,7 +20,10 @@ use crate::{
 };
 
 use super::layer::{draw_debug, draw_layer};
-use std::{collections::HashMap, iter::IntoIterator};
+use std::{
+    collections::{HashMap, HashSet},
+    iter::IntoIterator,
+};
 
 /// Creates a backdrop filter based on blend mode configuration.
 /// Returns an ImageFilter that can be applied to save layers.
@@ -110,7 +114,7 @@ pub fn draw_scene(canvas: &skia::Canvas, scene: std::sync::Arc<Scene>, root_id: 
                 let node = root.get();
                 let restore_point = canvas.save();
                 set_node_transform(node, canvas);
-                render_node_tree(root_id, scene_arena, renderables_arena, canvas, 1.0);
+                render_node_tree(root_id, scene_arena, renderables_arena, canvas, 1.0, None, None);
                 canvas.restore_to_count(restore_point);
             }
         });
@@ -287,19 +291,24 @@ pub fn paint_node_tree(
     context_opacity: f32,
     offscreen: bool,
     dbg_info: Option<&DrawDebugInfo>,
+    skip_self: bool,
+    occluded: Option<&HashSet<NodeRef>>,
+    damage_region: Option<&skia_safe::Region>,
 ) {
     let node_id: TreeStorageId = node_ref.into();
 
-    paint_node(
-        node_ref,
-        scene_arena,
-        renderables_arena,
-        render_canvas,
-        context_opacity,
-        offscreen,
-    );
-    if let Some(dbg_info) = dbg_info {
-        draw_debug(render_canvas, dbg_info, render_layer);
+    if !skip_self {
+        paint_node(
+            node_ref,
+            scene_arena,
+            renderables_arena,
+            render_canvas,
+            context_opacity,
+            offscreen,
+        );
+        if let Some(dbg_info) = dbg_info {
+            draw_debug(render_canvas, dbg_info, render_layer);
+        }
     }
     let mut context_opacity = render_layer.opacity * context_opacity;
     if (offscreen) {
@@ -314,8 +323,19 @@ pub fn paint_node_tree(
     // canvas.clip_rect(bounds, None, None);
     node_id.children(scene_arena).for_each(|child_id| {
         let child_ref = NodeRef(child_id);
-        let restore_point = render_canvas.save();
         let child = scene_arena.get(child_id).unwrap().get();
+
+        // Damage-based subtree culling: if the child (including all its
+        // descendants) falls entirely outside the damage region, skip it.
+        if let Some(region) = damage_region {
+            let child_bounds = child.render_layer.global_transformed_bounds_with_children;
+            let irect: skia_safe::IRect = child_bounds.round_out();
+            if !region.intersects_rect(irect) {
+                return;
+            }
+        }
+
+        let restore_point = render_canvas.save();
         set_node_transform(child, render_canvas);
         render_node_tree(
             child_ref,
@@ -323,6 +343,8 @@ pub fn paint_node_tree(
             renderables_arena,
             render_canvas,
             context_opacity,
+            occluded,
+            damage_region,
         );
         render_canvas.restore_to_count(restore_point);
     });
@@ -343,6 +365,8 @@ pub fn render_node_tree(
     renderables_arena: &FlatStorageData<SceneNodeRenderable>,
     render_canvas: &skia_safe::Canvas,
     context_opacity: f32,
+    occluded: Option<&HashSet<NodeRef>>,
+    damage_region: Option<&skia_safe::Region>,
 ) {
     let node_id: TreeStorageId = node_ref.into();
     #[cfg(feature = "profile-with-puffin")]
@@ -359,11 +383,15 @@ pub fn render_node_tree(
     if scene_node.hidden() {
         return;
     }
+    // Skip fully occluded nodes' own painting, but still traverse children.
+    // A child might be the occluder of its parent, so we cannot skip the subtree.
+    let is_self_occluded = occluded.map_or(false, |set| set.contains(&node_ref));
+
     let render_layer = &scene_node.render_layer;
     let restore_point = render_canvas.save();
     // render_canvas.concat(&render_layer.local_transform.to_m33());
     let dbg_info = scene_node._debug_info.as_ref();
-    if scene_node.is_image_cached() {
+    if scene_node.is_image_cached() && !is_self_occluded {
         #[cfg(feature = "profile-with-puffin")]
         profiling::puffin::profile_scope!("image_cached");
         // in this case the layer is ping-ponged
@@ -432,6 +460,9 @@ pub fn render_node_tree(
                             context_opacity,
                             true,
                             dbg_info,
+                            false, // not self-occluded (checked above)
+                            occluded,
+                            None, // damage is in screen-space, not offscreen-surface-space
                         );
                         // debug drawing
                         // let mut paint = skia_safe::Paint::default();
@@ -565,6 +596,9 @@ pub fn render_node_tree(
         context_opacity,
         false,
         dbg_info,
+        is_self_occluded,
+        occluded,
+        damage_region,
     );
 
     render_canvas.restore_to_count(restore_point);

--- a/src/engine/layers_engine.rs
+++ b/src/engine/layers_engine.rs
@@ -379,7 +379,9 @@ impl LayersEngine {
             let id = layer_ref.id().unwrap();
             let scene = engine_ref.scene();
             scene.with_arena(|arena| {
-                render_node_tree(id, arena, c, 1.0);
+                scene.with_renderable_arena(|renderable_arena| {
+                    render_node_tree(id, arena, renderable_arena, c, 1.0, None, None);
+                });
             });
             skia::Rect::from_xywh(0.0, 0.0, w, h)
         };

--- a/src/engine/layers_engine.rs
+++ b/src/engine/layers_engine.rs
@@ -148,7 +148,10 @@ impl LayersEngine {
     }
     /// Add a new layer to the scene
     /// The layer will be added to the root of the scene
-    pub fn add_layer(&self, layer: impl Into<Layer>) -> NodeRef {
+    pub fn add_layer(
+        &self,
+        layer: impl Into<Layer>,
+    ) -> Result<(), crate::layers::error::LayerError> {
         self.engine.append_layer(layer, None)
     }
     /// Add a new layer to the scene, attached to the given parent
@@ -158,7 +161,7 @@ impl LayersEngine {
         &self,
         layer: impl Into<Layer>,
         parent: impl Into<Option<NodeRef>>,
-    ) -> NodeRef {
+    ) -> Result<(), crate::layers::error::LayerError> {
         let parent = parent.into();
         self.engine.append_layer(layer, parent)
     }
@@ -169,7 +172,7 @@ impl LayersEngine {
         &self,
         layer: impl Into<Layer>,
         parent: impl Into<Option<NodeRef>>,
-    ) -> NodeRef {
+    ) -> Result<(), crate::layers::error::LayerError> {
         let parent = parent.into();
         self.engine.prepend_layer(layer, parent)
     }
@@ -181,7 +184,7 @@ impl LayersEngine {
         &self,
         layer: impl Into<Layer>,
         parent: impl Into<Option<NodeRef>>,
-    ) -> NodeRef {
+    ) -> Result<(), crate::layers::error::LayerError> {
         let parent = parent.into();
         self.engine.add_layer_to_positioned(layer, parent)
     }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -739,77 +739,93 @@ impl Engine {
     /// Append the layer's node to the scene tree and layout tree
     /// the layer is appended to the parent node if it is provided
     /// otherwise it is appended to the root of the scene
+    ///
+    /// Returns `Err(LayerError::StaleNode)` if the layer handle is stale.
     pub fn append_layer<'a>(
         &self,
         layer_id: impl Into<&'a NodeRef>,
         parent: impl Into<Option<NodeRef>>,
-    ) {
-        if std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            let layer_id = layer_id.into();
-            if let Some(layer) = self.get_layer(layer_id) {
-                let parent = parent.into();
-                self.layout_detach_layer(&layer);
-                let new_parent = parent.or_else(|| {
-                    let scene_root = *self.scene_root.read().unwrap();
-                    scene_root
-                });
+    ) -> Result<(), crate::layers::error::LayerError> {
+        let layer_id = layer_id.into();
+        let layer = self
+            .get_layer(layer_id)
+            .ok_or(crate::layers::error::LayerError::StaleNode)?;
 
-                if let Some(new_parent) = new_parent {
-                    self.scene.append_node_to(layer.id, new_parent);
-                    self.layout_append_layer(&layer, new_parent);
-                } else {
-                    // if we append to a scene without a root, we set the layer as the root
-                    self.scene_set_root(layer);
-                }
-                // Invalidate hit test node list since tree structure changed
-                self.invalidate_hit_test_node_list();
+        let parent = parent.into();
+        self.layout_detach_layer(&layer);
+        let new_parent = parent.or_else(|| {
+            let scene_root = *self.scene_root.read().unwrap();
+            scene_root
+        });
+
+        if let Some(new_parent) = new_parent {
+            // Verify the parent node is still alive before appending
+            if !self.is_layer_alive(&new_parent) {
+                return Err(crate::layers::error::LayerError::StaleNode);
             }
-        }))
-        .is_err()
-        {
-            error!("append_layer panicked (likely invalid layout node)");
+            self.scene.append_node_to(layer.id, new_parent);
+            self.layout_append_layer(&layer, new_parent);
+        } else {
+            self.scene_set_root(layer);
         }
+        self.invalidate_hit_test_node_list();
+        Ok(())
     }
 
     /// Append the layer to the root of the scene
     /// alias for append_layer, without a parent
-    pub fn add_layer<'a>(&self, layer: impl Into<&'a NodeRef>) {
+    pub fn add_layer<'a>(
+        &self,
+        layer: impl Into<&'a NodeRef>,
+    ) -> Result<(), crate::layers::error::LayerError> {
         self.append_layer(layer, None)
     }
 
     /// Prepend the layer to the root of the scene or to a parent node
     /// if the parent is provided
-    pub fn prepend_layer(&self, layer: impl Into<Layer>, parent: impl Into<Option<NodeRef>>) {
-        if std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            let layer: Layer = layer.into();
-            let layer_id = layer.id;
-            let parent = parent.into();
-            self.layout_detach_layer(&layer);
-
-            let new_parent = parent.or_else(|| {
-                let scene_root = *self.scene_root.read().unwrap();
-                scene_root
-            });
-
-            if let Some(new_parent) = new_parent {
-                self.scene.prepend_node_to(layer_id, new_parent);
-                self.layout_prepend_layer(&layer, new_parent);
-            } else {
-                // if we append to a scene without a root, we set the layer as the root
-                self.scene_set_root(layer);
-            }
-            // Invalidate hit test node list since tree structure changed
-            self.invalidate_hit_test_node_list();
-        }))
-        .is_err()
-        {
-            error!("prepend_layer panicked (likely invalid layout node)");
+    ///
+    /// Returns `Err(LayerError::StaleNode)` if the layer handle is stale.
+    pub fn prepend_layer(
+        &self,
+        layer: impl Into<Layer>,
+        parent: impl Into<Option<NodeRef>>,
+    ) -> Result<(), crate::layers::error::LayerError> {
+        let layer: Layer = layer.into();
+        if !self.is_layer_alive(&layer.id) {
+            return Err(crate::layers::error::LayerError::StaleNode);
         }
+        let layer_id = layer.id;
+        let parent = parent.into();
+        self.layout_detach_layer(&layer);
+
+        let new_parent = parent.or_else(|| {
+            let scene_root = *self.scene_root.read().unwrap();
+            scene_root
+        });
+
+        if let Some(new_parent) = new_parent {
+            // Verify the parent node is still alive before prepending
+            if !self.is_layer_alive(&new_parent) {
+                return Err(crate::layers::error::LayerError::StaleNode);
+            }
+            self.scene.prepend_node_to(layer_id, new_parent);
+            self.layout_prepend_layer(&layer, new_parent);
+        } else {
+            self.scene_set_root(layer);
+        }
+        self.invalidate_hit_test_node_list();
+        Ok(())
     }
 
-    pub fn add_layer_to_positioned(&self, layer: impl Into<Layer>, parent: Option<NodeRef>) {
-        // FIXME ensure that newly added layers are layouted
-        // update...
+    /// Append the layer to the parent, adjusting its position to preserve its
+    /// current global position relative to the new parent.
+    ///
+    /// Returns `Err(LayerError::StaleNode)` if the layer handle is stale.
+    pub fn add_layer_to_positioned(
+        &self,
+        layer: impl Into<Layer>,
+        parent: Option<NodeRef>,
+    ) -> Result<(), crate::layers::error::LayerError> {
         {
             execute_transactions(self);
             update_layout_tree(self);
@@ -817,6 +833,9 @@ impl Engine {
         }
 
         let layer: Layer = layer.into();
+        if !self.is_layer_alive(&layer.id) {
+            return Err(crate::layers::error::LayerError::StaleNode);
+        }
         let position = layer.render_position();
         let parent_position = parent
             .and_then(|parent| {
@@ -833,7 +852,7 @@ impl Engine {
             y: position.y - parent_position.y,
         };
 
-        self.append_layer(&layer.id, parent);
+        self.append_layer(&layer.id, parent)?;
 
         layer.set_position(new_position, None);
         {
@@ -841,12 +860,7 @@ impl Engine {
             update_layout_tree(self);
             self.update_nodes();
         }
-
-        // println!("current position {:?}", position);
-        // println!("parent position {:?}", parent_position);
-        // println!("new model position {:?}", new_position);
-        // let new_position = layer.render_position();
-        // println!("new render position {:?}", new_position);
+        Ok(())
     }
 
     pub fn mark_for_delete(&self, layer: NodeRef) {

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -36,6 +36,7 @@ pub(crate) mod scene;
 
 pub mod animation;
 pub(crate) mod node;
+pub mod occlusion;
 pub(crate) mod storage;
 pub mod task;
 
@@ -2051,7 +2052,7 @@ impl Engine {
 
             // Try-lock to avoid blocking while a writer holds (or waits on) the arenas.
             if let (Ok(nodes), Ok(renderables)) = (nodes.try_read(), renderables.try_read()) {
-                render_node_tree(layer_id, &nodes, &renderables, c, 1.0);
+                render_node_tree(layer_id, &nodes, &renderables, c, 1.0, None, None);
             }
             skia::Rect::from_xywh(0.0, 0.0, w, h)
         };
@@ -2063,6 +2064,28 @@ impl Engine {
     pub fn clear_damage(&self) {
         let mut damage = self.damage.write().unwrap();
         *damage = skia_safe::Rect::default();
+    }
+
+    /// Compute occlusion culling for the given root node.
+    ///
+    /// Traverses the subtree front-to-back and marks nodes that are fully
+    /// hidden behind opaque layers. Results are stored on the `Scene` and
+    /// used by `render_node_tree` to skip occluded nodes.
+    ///
+    /// Call this after `update()` for each root node you intend to draw.
+    pub fn compute_occlusion(&self, root: NodeRef) {
+        let occluded = self
+            .scene
+            .with_arena(|arena| occlusion::compute_occlusion(root, arena));
+        self.scene.add_occlusion(root, occluded);
+    }
+
+    /// Clear all cached occlusion data.
+    ///
+    /// Call this before recomputing occlusion for a new frame to avoid
+    /// stale entries from previous roots.
+    pub fn clear_occlusion(&self) {
+        self.scene.clear_occlusion();
     }
     pub fn add_damage(&self, rect: skia_safe::Rect) {
         let mut damage = self.damage.write().unwrap();

--- a/src/engine/node/mod.rs
+++ b/src/engine/node/mod.rs
@@ -188,8 +188,21 @@ impl SceneNode {
     pub fn is_picture_cached(&self) -> bool {
         self.picture_cached
     }
+    /// Hint that the custom draw content fills the entire bounds with opaque
+    /// pixels. When set, the layer can act as an occluder for occlusion culling
+    /// even when its background color is transparent.
+    pub fn set_content_opaque(&mut self, value: bool) {
+        self.render_layer.content_opaque = value;
+    }
+    pub fn is_content_opaque(&self) -> bool {
+        self.render_layer.content_opaque
+    }
     pub fn render_layer(&self) -> &RenderLayer {
         &self.render_layer
+    }
+    /// Mutable access to the render layer for testing and diagnostic tools.
+    pub fn render_layer_mut(&mut self) -> &mut RenderLayer {
+        &mut self.render_layer
     }
     pub(crate) fn increase_frame(&mut self) {
         // if self.is_image_cached() {

--- a/src/engine/occlusion.rs
+++ b/src/engine/occlusion.rs
@@ -138,14 +138,8 @@ fn collect_draw_order(
         false
     };
 
-    // The node's own visible region (for occluder contribution and occlusion test)
     let visible_bounds = if let Some(clip) = clip_rect {
-        let intersected = intersect_rects(bounds, clip);
-        if intersected.is_empty() {
-            bounds
-        } else {
-            intersected
-        }
+        intersect_rects(bounds, clip)
     } else {
         bounds
     };

--- a/src/engine/occlusion.rs
+++ b/src/engine/occlusion.rs
@@ -1,0 +1,193 @@
+//! Occlusion culling for the rendering pipeline.
+//!
+//! After the engine updates node transforms and bounds, this module traverses
+//! the scene front-to-back and identifies layers that are fully hidden behind
+//! opaque layers. Occluded nodes are collected into a set so the drawing code
+//! can skip them.
+//!
+//! The computation accepts an arbitrary root node so that scenes drawn from
+//! different starting points each get their own occlusion data.
+//!
+//! Clip-awareness: when a parent has `clip_children = true`, child bounds are
+//! intersected with the parent clip. Children fully outside the clip are marked
+//! occluded. Opaque layers only contribute the intersection of their bounds
+//! with the active clip to the occlusion mask.
+
+use std::collections::{HashMap, HashSet};
+
+use indextree::Arena;
+use skia_safe::Contains;
+
+use crate::engine::node::SceneNode;
+use crate::engine::storage::TreeStorageId;
+use crate::engine::NodeRef;
+
+/// Per-root occlusion data: the set of node ids that are fully occluded.
+pub type OcclusionMap = HashMap<NodeRef, HashSet<NodeRef>>;
+
+/// Compute the set of occluded nodes for a given root.
+///
+/// The algorithm flattens the subtree rooted at `root` into draw order
+/// (back-to-front via pre-order traversal), then iterates **front-to-back**
+/// (reversed). Fully-opaque rectangular layers contribute their global bounds
+/// (clipped to any ancestor clip region) to an occlusion list. Any subsequent
+/// (i.e. behind) node whose visible bounds are fully contained by an opaque
+/// rect is marked occluded.
+///
+/// Nodes whose bounds fall entirely outside an ancestor's `clip_children`
+/// region are also marked occluded since they produce no visible pixels.
+#[profiling::function]
+pub fn compute_occlusion(root: NodeRef, arena: &Arena<SceneNode>) -> HashSet<NodeRef> {
+    let root_id: TreeStorageId = root.into();
+
+    // Collect nodes in draw order (pre-order = back-to-front),
+    // along with context opacity and the active clip rect.
+    let mut draw_order: Vec<NodeOcclusionInfo> = Vec::new();
+    collect_draw_order(root_id, arena, 1.0, None, &mut draw_order);
+
+    // Front-to-back iteration (reverse of draw order).
+    let mut opaque_rects: Vec<skia_safe::Rect> = Vec::new();
+    let mut occluded = HashSet::new();
+
+    for info in draw_order.iter().rev() {
+        // Entire subtree is outside an ancestor clip — always skip
+        if info.clipped_out {
+            occluded.insert(info.node_ref);
+            continue;
+        }
+
+        let visible_bounds = info.visible_bounds;
+
+        // Zero-size nodes produce no pixels on their own but may have visible
+        // children. Never mark them as occluded and never use them as occluders.
+        if visible_bounds.width() <= 0.0 || visible_bounds.height() <= 0.0 {
+            continue;
+        }
+
+        // Check if this node is fully covered by any existing opaque rect
+        let is_occluded = opaque_rects
+            .iter()
+            .any(|rect| rect.contains(visible_bounds));
+
+        if is_occluded {
+            occluded.insert(info.node_ref);
+            continue;
+        }
+
+        // If this layer is fully opaque, add its *clipped* bounds to the mask
+        if info.is_opaque {
+            opaque_rects.push(visible_bounds);
+        }
+    }
+
+    occluded
+}
+
+struct NodeOcclusionInfo {
+    node_ref: NodeRef,
+    /// The node bounds intersected with the active clip (what is actually visible).
+    visible_bounds: skia_safe::Rect,
+    /// Whether the node is fully opaque and can act as an occluder.
+    is_opaque: bool,
+    /// Whether the node (including its children) is entirely outside its ancestor clip region.
+    clipped_out: bool,
+}
+
+/// Pre-order traversal collecting occlusion info in draw order.
+///
+/// `clip_rect` is the intersection of all ancestor `clip_children` bounds
+/// in global coordinates. `None` means no clipping is active.
+fn collect_draw_order(
+    node_id: TreeStorageId,
+    arena: &Arena<SceneNode>,
+    context_opacity: f32,
+    clip_rect: Option<skia_safe::Rect>,
+    out: &mut Vec<NodeOcclusionInfo>,
+) {
+    let Some(node) = arena.get(node_id) else {
+        return;
+    };
+    if node.is_removed() {
+        return;
+    }
+    let scene_node = node.get();
+
+    // Hidden nodes and their entire subtree are invisible — skip them.
+    if scene_node.hidden() {
+        return;
+    }
+
+    let opacity = scene_node.render_layer.opacity * context_opacity;
+
+    // Fully transparent subtrees produce no pixels — skip entirely.
+    if opacity <= 0.0 {
+        return;
+    }
+
+    let render_layer = &scene_node.render_layer;
+    let bounds = render_layer.global_transformed_bounds;
+    let bounds_with_children = render_layer.global_transformed_bounds_with_children;
+
+    // Compute visible bounds: intersect with active clip.
+    // Use bounds_with_children for the clip-out test so that a zero-size
+    // container whose children have visible area is not incorrectly culled.
+    let clipped_out = if let Some(clip) = clip_rect {
+        let child_area = intersect_rects(bounds_with_children, clip);
+        child_area.is_empty()
+    } else {
+        false
+    };
+
+    // The node's own visible region (for occluder contribution and occlusion test)
+    let visible_bounds = if let Some(clip) = clip_rect {
+        let intersected = intersect_rects(bounds, clip);
+        if intersected.is_empty() {
+            bounds
+        } else {
+            intersected
+        }
+    } else {
+        bounds
+    };
+
+    // A node is only an occluder when it AND all its ancestors are fully opaque.
+    // Layers with opacity < 1.0, hidden parents, or semi-transparent subtrees
+    // never contribute to the occlusion mask (but can still be occluded).
+    let is_opaque = !clipped_out && render_layer.is_fully_opaque() && context_opacity >= 1.0;
+
+    out.push(NodeOcclusionInfo {
+        node_ref: NodeRef(node_id),
+        visible_bounds,
+        is_opaque,
+        clipped_out,
+    });
+
+    // Compute the clip rect for children
+    let child_clip = if render_layer.clip_children {
+        // Intersect this node's global bounds with the existing clip
+        let node_clip = render_layer.global_transformed_bounds;
+        Some(match clip_rect {
+            Some(parent_clip) => intersect_rects(parent_clip, node_clip),
+            None => node_clip,
+        })
+    } else {
+        clip_rect
+    };
+
+    for child_id in node_id.children(arena).collect::<Vec<_>>() {
+        collect_draw_order(child_id, arena, opacity, child_clip, out);
+    }
+}
+
+/// Intersect two rects, returning an empty rect if they don't overlap.
+fn intersect_rects(a: skia_safe::Rect, b: skia_safe::Rect) -> skia_safe::Rect {
+    let left = a.left.max(b.left);
+    let top = a.top.max(b.top);
+    let right = a.right.min(b.right);
+    let bottom = a.bottom.min(b.bottom);
+    if left < right && top < bottom {
+        skia_safe::Rect::from_ltrb(left, top, right, bottom)
+    } else {
+        skia_safe::Rect::default()
+    }
+}

--- a/src/engine/scene.rs
+++ b/src/engine/scene.rs
@@ -74,7 +74,19 @@ impl Scene {
         self.occlusion_map.read().ok().map(|m| m.clone())
     }
 
-    /// Store occlusion data for the given root node (additive).
+    /// Returns a clone of the occluded-node set for the given root, without
+    /// cloning the entire map.
+    pub fn occluded_set(
+        &self,
+        root: super::NodeRef,
+    ) -> Option<std::collections::HashSet<super::NodeRef>> {
+        self.occlusion_map
+            .read()
+            .ok()
+            .and_then(|m| m.get(&root).cloned())
+    }
+
+    /// Store occlusion data for the given root node, replacing any existing entry.
     pub(crate) fn add_occlusion(
         &self,
         root: super::NodeRef,
@@ -450,7 +462,7 @@ mod tests {
         let child = engine.new_layer();
         child.set_key("child");
         let child_id = child.id();
-        root.add_sublayer(&child_id);
+        root.add_sublayer(&child_id).unwrap();
 
         engine.update(0.0);
 

--- a/src/engine/scene.rs
+++ b/src/engine/scene.rs
@@ -5,6 +5,7 @@
 //! The tree is stored in a memory arena using IndexTree, which allow fast read/write and thread safe parallel iterations.
 
 use crate::{
+    engine::occlusion::OcclusionMap,
     engine::storage::{FlatStorage, FlatStorageData},
     layers::layer::render_layer::RenderLayer,
     prelude::Point,
@@ -40,6 +41,10 @@ pub struct Scene {
     pub(crate) renderables: FlatStorage<SceneNodeRenderable>,
 
     pub size: RwLock<Point>,
+
+    /// Per-root occlusion data: maps a root NodeRef to the set of nodes
+    /// that are fully occluded when drawing from that root.
+    occlusion_map: RwLock<OcclusionMap>,
 }
 
 impl Scene {
@@ -53,6 +58,7 @@ impl Scene {
                 x: width,
                 y: height,
             }),
+            occlusion_map: RwLock::new(std::collections::HashMap::new()),
         }
     }
     pub fn set_size(&self, width: f32, height: f32) {
@@ -61,6 +67,29 @@ impl Scene {
             x: width,
             y: height,
         };
+    }
+
+    /// Returns a snapshot of the occlusion map (root -> occluded node set).
+    pub fn occlusion_map(&self) -> Option<OcclusionMap> {
+        self.occlusion_map.read().ok().map(|m| m.clone())
+    }
+
+    /// Store occlusion data for the given root node (additive).
+    pub(crate) fn add_occlusion(
+        &self,
+        root: super::NodeRef,
+        occluded: std::collections::HashSet<super::NodeRef>,
+    ) {
+        if let Ok(mut map) = self.occlusion_map.write() {
+            map.insert(root, occluded);
+        }
+    }
+
+    /// Clear all cached occlusion data.
+    pub(crate) fn clear_occlusion(&self) {
+        if let Ok(mut map) = self.occlusion_map.write() {
+            map.clear();
+        }
     }
     pub(crate) fn create(width: f32, height: f32) -> Arc<Scene> {
         Arc::new(Self::new(width, height))

--- a/src/engine/stages/update_node.rs
+++ b/src/engine/stages/update_node.rs
@@ -395,7 +395,7 @@ mod tests {
         layer.set_position((100.0, 100.0), None);
         layer.set_background_color(Color::new_hex("#ff0000ff"), None);
         layer.set_size(Size::points(100.0, 100.0), None);
-        engine.add_layer(&layer);
+        let _ = engine.add_layer(&layer);
 
         // Prime initial state so previous bounds are non-empty
         engine.update(0.016);
@@ -429,7 +429,7 @@ mod tests {
             },
             None,
         );
-        engine.add_layer(&layer);
+        let _ = engine.add_layer(&layer);
 
         // Prime baseline (opacity = 1.0)
         engine.update(0.016);
@@ -477,7 +477,7 @@ mod tests {
         let layer = engine.new_layer();
         layer.set_position((100.0, 100.0), None);
         layer.set_size(Size::points(100.0, 100.0), None);
-        engine.add_layer(&layer);
+        let _ = engine.add_layer(&layer);
 
         // Prime initial state
         engine.update(0.016);
@@ -514,7 +514,7 @@ mod tests {
             },
             None,
         );
-        engine.add_layer(&layer);
+        let _ = engine.add_layer(&layer);
 
         // Prime initial state so previous/new states are identical and stable
         engine.update(0.016);
@@ -542,8 +542,8 @@ mod tests {
         let child = engine.new_layer();
         child.set_position((5.0, 5.0), None);
 
-        engine.add_layer(&parent);
-        engine.append_layer(&child.id, Some(parent.id));
+        let _ = engine.add_layer(&parent);
+        let _ = engine.append_layer(&child.id, Some(parent.id));
 
         // Prime initial layout/state
         engine.update(0.016);

--- a/src/layers/error.rs
+++ b/src/layers/error.rs
@@ -1,0 +1,20 @@
+/// Errors returned by layer and engine operations.
+#[derive(Debug, Clone)]
+pub enum LayerError {
+    /// The layer's scene-graph node has been removed or freed.
+    ///
+    /// This typically happens when a layer handle outlives the node it
+    /// refers to — e.g. an animation callback fires after the layer
+    /// was deleted.
+    StaleNode,
+}
+
+impl std::fmt::Display for LayerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LayerError::StaleNode => write!(f, "layer node has been removed or freed"),
+        }
+    }
+}
+
+impl std::error::Error for LayerError {}

--- a/src/layers/layer/mod.rs
+++ b/src/layers/layer/mod.rs
@@ -676,6 +676,17 @@ impl Layer {
         });
     }
 
+    /// Declare that the custom draw content fills the entire layer bounds with
+    /// opaque pixels. This allows occlusion culling to treat the layer as an
+    /// occluder even when its background color is transparent.
+    pub fn set_content_opaque(&self, content_opaque: bool) {
+        self.engine.scene.with_arena_mut(|arena| {
+            if let Some(node) = arena.get_mut(self.id.0).filter(|n| !n.is_removed()) {
+                node.get_mut().set_content_opaque(content_opaque);
+            }
+        });
+    }
+
     pub fn set_picture_cached(&self, picture_cache: bool) {
         self.engine.scene.with_arena_mut(|arena| {
             if let Some(node) = arena.get_mut(self.id.0).filter(|n| !n.is_removed()) {
@@ -731,7 +742,7 @@ impl Layer {
             let damage = scene
                 .try_with_arena(|arena| {
                     scene.with_renderable_arena(|renderable_arena| {
-                        render_node_tree(layer_id, arena, renderable_arena, c, 1.0);
+                        render_node_tree(layer_id, arena, renderable_arena, c, 1.0, None, None);
                     });
                     // the damage of a mirrored layer is the bounds with children
                     if let Some(scene_node) = arena.get(layer_id.0) {

--- a/src/layers/layer/mod.rs
+++ b/src/layers/layer/mod.rs
@@ -379,11 +379,14 @@ impl Layer {
         self.engine
             .set_node_flags(self.id, RenderableFlags::NEEDS_PAINT);
     }
-    pub fn add_sublayer<'a>(&self, layer: impl Into<&'a NodeRef>) {
+    pub fn add_sublayer<'a>(
+        &self,
+        layer: impl Into<&'a NodeRef>,
+    ) -> Result<(), crate::layers::error::LayerError> {
         self.engine.append_layer(layer, self.id)
     }
 
-    pub fn prepend_sublayer(&self, layer: Layer) {
+    pub fn prepend_sublayer(&self, layer: Layer) -> Result<(), crate::layers::error::LayerError> {
         self.engine.prepend_layer(layer, self.id)
     }
 

--- a/src/layers/layer/render_layer.rs
+++ b/src/layers/layer/render_layer.rs
@@ -305,8 +305,8 @@ impl RenderLayer {
 
         // Either the background is fully opaque, or the user declared the
         // custom draw content fills the bounds with opaque pixels.
-        let has_opaque_fill = self.content_opaque
-            || Self::paint_color_min_alpha(&self.background_color) >= 1.0;
+        let has_opaque_fill =
+            self.content_opaque || Self::paint_color_min_alpha(&self.background_color) >= 1.0;
         if !has_opaque_fill {
             return false;
         }

--- a/src/layers/layer/render_layer.rs
+++ b/src/layers/layer/render_layer.rs
@@ -84,6 +84,10 @@ pub struct RenderLayer {
     pub backdrop_blur_region: Option<Vec<skia_safe::RRect>>,
     /// The shape definition for this layer
     pub shape: Shape,
+    /// Hint from the user that the custom draw content fills the entire bounds
+    /// with opaque pixels. When true, the layer can act as an occluder even if
+    /// its background color is transparent.
+    pub content_opaque: bool,
 }
 
 impl RenderLayer {
@@ -272,6 +276,56 @@ impl RenderLayer {
                 gradient.colors.iter().fold(0.0, |acc, c| acc.max(c.alpha))
             }
         }
+    }
+
+    fn paint_color_min_alpha(color: &PaintColor) -> f32 {
+        match color {
+            PaintColor::Solid { color } => color.alpha,
+            PaintColor::GradientLinear(gradient) => {
+                gradient.colors.iter().fold(1.0, |acc, c| acc.min(c.alpha))
+            }
+            PaintColor::GradientRadial(gradient) => {
+                gradient.colors.iter().fold(1.0, |acc, c| acc.min(c.alpha))
+            }
+        }
+    }
+
+    /// Returns true if this layer is fully opaque and can act as an occluder,
+    /// meaning it completely hides any content behind its bounds.
+    pub fn is_fully_opaque(&self) -> bool {
+        // Must be fully opaque (including parent opacity chain)
+        if self.premultiplied_opacity < 1.0 {
+            return false;
+        }
+
+        // BackgroundBlur reads from the backdrop, so it can't occlude
+        if self.blend_mode != BlendMode::Normal {
+            return false;
+        }
+
+        // Either the background is fully opaque, or the user declared the
+        // custom draw content fills the bounds with opaque pixels.
+        let has_opaque_fill = self.content_opaque
+            || Self::paint_color_min_alpha(&self.background_color) >= 1.0;
+        if !has_opaque_fill {
+            return false;
+        }
+
+        // Rounded corners leave transparent regions in the bounding rect
+        if self.border_corner_radius.top_left > 0.0
+            || self.border_corner_radius.top_right > 0.0
+            || self.border_corner_radius.bottom_right > 0.0
+            || self.border_corner_radius.bottom_left > 0.0
+        {
+            return false;
+        }
+
+        // Custom path shapes may not cover the full bounding rect
+        if !matches!(self.shape, Shape::RoundRect) {
+            return false;
+        }
+
+        true
     }
 
     /// Generate the shape path in local coordinates on-demand.
@@ -484,6 +538,7 @@ impl RenderLayer {
                 .load(std::sync::atomic::Ordering::Relaxed),
             visible: true,
             backdrop_blur_region: None,
+            content_opaque: false,
         };
 
         render_layer.visible = render_layer.has_visible_drawables();
@@ -547,6 +602,7 @@ impl Default for RenderLayer {
             pointer_events: false,
             visible: false,
             backdrop_blur_region: None,
+            content_opaque: false,
         }
     }
 }

--- a/src/layers/mod.rs
+++ b/src/layers/mod.rs
@@ -1,3 +1,4 @@
 //! Internal models representing the Layers and their animatable properties.
 
+pub mod error;
 pub mod layer;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -9,6 +9,7 @@ pub use super::{
         AnimationRef, Engine, NodeRef, TransactionRef,
     },
     layers::{
+        error::LayerError,
         layer::model::{ContentDrawError, ContentDrawFunction, PointerHandlerFunction},
         layer::Effect,
         layer::Layer,

--- a/src/renderer/skia_fbo.rs
+++ b/src/renderer/skia_fbo.rs
@@ -123,10 +123,7 @@ impl DrawScene for SkiaFboRenderer {
                 if let Some(root) = arena.get(root_id.into()) {
                     let root = root.get();
                     set_node_transform(root, canvas);
-                    let occluded = {
-                        let occ_map = scene.occlusion_map().unwrap_or_default();
-                        occ_map.get(&root_id).cloned()
-                    };
+                    let occluded = scene.occluded_set(root_id);
                     render_node_tree(
                         root_id,
                         arena,

--- a/src/renderer/skia_fbo.rs
+++ b/src/renderer/skia_fbo.rs
@@ -16,6 +16,7 @@ use crate::{
     engine::{node::SceneNode, scene::Scene, NodeRef},
 };
 use crate::{drawing::scene::DrawScene, layers::layer::render_layer, prelude::render_node_tree};
+use std::collections::HashSet;
 
 #[derive(Clone)]
 pub struct SkiaFboRenderer {
@@ -122,7 +123,19 @@ impl DrawScene for SkiaFboRenderer {
                 if let Some(root) = arena.get(root_id.into()) {
                     let root = root.get();
                     set_node_transform(root, canvas);
-                    render_node_tree(root_id, arena, renderable_arena, &mut canvas, 1.0);
+                    let occluded = {
+                        let occ_map = scene.occlusion_map().unwrap_or_default();
+                        occ_map.get(&root_id).cloned()
+                    };
+                    render_node_tree(
+                        root_id,
+                        arena,
+                        renderable_arena,
+                        &mut canvas,
+                        1.0,
+                        occluded.as_ref(),
+                        None,
+                    );
                 }
             });
         });

--- a/src/view/build_layer_tree.rs
+++ b/src/view/build_layer_tree.rs
@@ -234,7 +234,13 @@ impl BuildLayerTree for Layer {
                         // is_node_removed hasn't caught it yet
                         if !engine.scene.is_node_removed(child_layer_id) {
                             if let Some(child_layer) = engine.get_layer(&child_layer_id) {
-                                engine.append_layer(&child_layer.id, Some(layer_id));
+                                if let Err(e) = engine.append_layer(&child_layer.id, Some(layer_id))
+                                {
+                                    tracing::warn!(
+                                        "build_layer_tree: failed to reattach child: {e}"
+                                    );
+                                    return None;
+                                }
                                 return Some((child_layer_id, child_layer));
                             }
                         }
@@ -243,7 +249,7 @@ impl BuildLayerTree for Layer {
                     .unwrap_or_else(|| {
                         // the child layer does not exist, is removed, or is stale — create fresh
                         let layer = engine.new_layer();
-                        engine.append_layer(&layer, Some(layer_id));
+                        let _ = engine.append_layer(&layer, Some(layer_id));
                         (layer.id, layer)
                     });
 

--- a/src/view/build_layer_tree.rs
+++ b/src/view/build_layer_tree.rs
@@ -227,7 +227,7 @@ impl BuildLayerTree for Layer {
                 let child_layer_id = nodes.pop_front();
 
                 // get or create the child layer
-                let (child_layer_id, child_layer) = child_layer_id
+                let maybe_layer = child_layer_id
                     .and_then(|child_layer_id| {
                         // try to use existing layer — also check get_layer in case the layer was
                         // removed from the HashMap (scene_remove_layer cleans it up) even if
@@ -246,13 +246,24 @@ impl BuildLayerTree for Layer {
                         }
                         None
                     })
-                    .unwrap_or_else(|| {
+                    .or_else(|| {
                         // the child layer does not exist, is removed, or is stale — create fresh
                         let layer = engine.new_layer();
-                        let _ = engine.append_layer(&layer, Some(layer_id));
-                        (layer.id, layer)
+                        match engine.append_layer(&layer, Some(layer_id)) {
+                            Ok(()) => Some((layer.id, layer)),
+                            Err(e) => {
+                                tracing::error!(
+                                    "build_layer_tree: failed to append fresh child layer: {}",
+                                    e
+                                );
+                                None
+                            }
+                        }
                     });
 
+                let Some((child_layer_id, child_layer)) = maybe_layer else {
+                    continue;
+                };
                 layer_view_map.retain(|n, _| !node_same_index(n.0, child_layer_id.0));
                 cache_remove_id(&child_layer_id, cache_viewlayer);
                 drop(nodes);

--- a/tests/animations.rs
+++ b/tests/animations.rs
@@ -5,7 +5,7 @@ use layers::prelude::*;
 pub fn linear_animation() {
     let engine = Engine::create(1000.0, 1000.0);
     let layer = engine.new_layer();
-    engine.add_layer(&layer);
+    engine.add_layer(&layer).unwrap();
 
     layer
         .set_opacity(0.0, Some(Transition::linear(1.0)))
@@ -81,7 +81,7 @@ pub fn spring_animation() {
 pub fn spring_animation_with_delay() {
     let engine = Engine::create(1000.0, 1000.0);
     let layer = engine.new_layer();
-    engine.add_layer(&layer);
+    engine.add_layer(&layer).unwrap();
 
     let initial_position = layer.position();
 
@@ -118,7 +118,7 @@ pub fn spring_animation_with_delay() {
 pub fn merge_spring_animation() {
     let engine = Engine::create(1000.0, 1000.0);
     let layer = engine.new_layer();
-    engine.add_layer(&layer);
+    engine.add_layer(&layer).unwrap();
 
     let tr = layer.set_position((10.0, 10.0), Transition::spring(2.0, 0.2));
 

--- a/tests/damage.rs
+++ b/tests/damage.rs
@@ -14,7 +14,7 @@ mod tests {
         layer.set_position((100.0, 100.0), None);
         layer.set_size(Size::points(100.0, 100.0), None);
 
-        engine.add_layer(&layer);
+        engine.add_layer(&layer).unwrap();
 
         engine.update(0.016);
 
@@ -35,7 +35,7 @@ mod tests {
         let layer = engine.new_layer();
 
         layer.set_size(Size::points(100.0, 100.0), None);
-        engine.append_layer(&layer.id, None);
+        engine.append_layer(&layer.id, None).unwrap();
 
         engine.update(0.016);
 
@@ -63,7 +63,7 @@ mod tests {
         layer.set_position((100.0, 100.0), None);
         layer.set_size(Size::points(100.0, 100.0), None);
 
-        engine.add_layer(&layer);
+        engine.add_layer(&layer).unwrap();
 
         engine.update(0.016);
 
@@ -97,7 +97,7 @@ mod tests {
         layer.set_position((100.0, 100.0), None);
         layer.set_size(Size::points(100.0, 100.0), None);
 
-        engine.add_layer(&layer.id);
+        engine.add_layer(&layer.id).unwrap();
 
         engine.update(0.016);
 
@@ -135,7 +135,7 @@ mod tests {
         layer.set_position((100.0, 100.0), None);
         layer.set_size(Size::points(100.0, 100.0), None);
 
-        engine.add_layer(&layer.id);
+        engine.add_layer(&layer.id).unwrap();
 
         engine.update(0.016);
 
@@ -166,19 +166,19 @@ mod tests {
         let root = engine.new_layer();
         root.set_position((0.0, 0.0), None);
         root.set_size(Size::points(600.0, 600.0), None);
-        engine.add_layer(&root.id);
+        engine.add_layer(&root.id).unwrap();
 
         let hidden_parent = engine.new_layer();
         hidden_parent.set_position((100.0, 100.0), None);
         hidden_parent.set_size(Size::points(300.0, 300.0), None);
         hidden_parent.set_hidden(true);
-        engine.append_layer(&hidden_parent.id, Some(root.id));
+        engine.append_layer(&hidden_parent.id, Some(root.id)).unwrap();
 
         let child = engine.new_layer();
         child.set_position((20.0, 20.0), None);
         child.set_size(Size::points(100.0, 100.0), None);
         child.set_blend_mode(layers::types::BlendMode::BackgroundBlur);
-        engine.append_layer(&child.id, Some(hidden_parent.id));
+        engine.append_layer(&child.id, Some(hidden_parent.id)).unwrap();
 
         engine.update(0.016);
 
@@ -198,7 +198,7 @@ mod tests {
             },
             None,
         );
-        engine.add_layer(&layer.id);
+        engine.add_layer(&layer.id).unwrap();
         engine.update(0.016);
 
         let scene_damage = engine.damage();
@@ -215,7 +215,7 @@ mod tests {
         let layer = engine.new_layer();
         layer.set_position((100.0, 100.0), None);
         layer.set_size(Size::points(100.0, 100.0), None);
-        engine.add_layer(&layer.id);
+        engine.add_layer(&layer.id).unwrap();
         engine.update(0.016);
         let scene_damage = engine.damage();
         // adding an empty layer should not damage the content
@@ -244,12 +244,12 @@ mod tests {
         layer.set_position((100.0, 100.0), None);
         layer.set_size(Size::points(100.0, 100.0), None);
         // layer.set_image_cache(true);
-        engine.add_layer(&layer.id);
+        engine.add_layer(&layer.id).unwrap();
 
         let layer2 = engine.new_layer();
         layer2.set_position((100.0, 100.0), None);
         layer2.set_size(Size::points(100.0, 100.0), None);
-        engine.append_layer(&layer2, layer.id);
+        engine.append_layer(&layer2, layer.id).unwrap();
 
         engine.update(0.016);
         let scene_damage = engine.damage();
@@ -290,22 +290,22 @@ mod tests {
         let layer = engine.new_layer();
         layer.set_position((50.0, 70.0), None);
         layer.set_size(Size::points(120.0, 120.0), None);
-        engine.add_layer(&layer.id);
+        engine.add_layer(&layer.id).unwrap();
 
         let child_a = engine.new_layer();
         child_a.set_position((25.0, 15.0), None);
         child_a.set_size(Size::points(100.0, 100.0), None);
-        engine.append_layer(&child_a, layer.id);
+        engine.append_layer(&child_a, layer.id).unwrap();
 
         let child_b = engine.new_layer();
         child_b.set_position((10.0, 12.0), None);
         child_b.set_size(Size::points(80.0, 80.0), None);
-        engine.append_layer(&child_b, child_a.id);
+        engine.append_layer(&child_b, child_a.id).unwrap();
 
         let child_c = engine.new_layer();
         child_c.set_position((4.0, 3.0), None);
         child_c.set_size(Size::points(60.0, 60.0), None);
-        engine.append_layer(&child_c, child_b.id);
+        engine.append_layer(&child_c, child_b.id).unwrap();
 
         engine.update(0.016);
         let scene_damage = engine.damage();
@@ -337,7 +337,7 @@ mod tests {
         let layer = engine.new_layer();
         layer.set_position((100.0, 100.0), None);
         layer.set_size(Size::points(100.0, 100.0), None);
-        engine.add_layer(&layer.id);
+        engine.add_layer(&layer.id).unwrap();
 
         engine.update(0.016);
         let scene_damage = engine.damage();
@@ -356,7 +356,7 @@ mod tests {
             },
             None,
         );
-        engine.add_layer(&layer.id);
+        engine.add_layer(&layer.id).unwrap();
 
         let draw_func = |_c: &skia_safe::Canvas, _w: f32, _h: f32| -> skia_safe::Rect {
             skia_safe::Rect::from_xywh(0.0, 0.0, 10.0, 10.0)
@@ -383,7 +383,7 @@ mod tests {
             },
             None,
         );
-        engine.add_layer(&layer.id);
+        engine.add_layer(&layer.id).unwrap();
 
         engine.update(0.016);
         let scene_damage = engine.damage();
@@ -422,13 +422,13 @@ mod tests {
         let parent = engine.new_layer();
         parent.set_position((100.0, 100.0), None);
         parent.set_size(Size::points(100.0, 100.0), None);
-        engine.add_layer(&parent.id);
+        engine.add_layer(&parent.id).unwrap();
 
         let child = engine.new_layer();
         child.set_position((0.0, 0.0), None);
         child.set_size(Size::points(100.0, 100.0), None);
         child.set_background_color(Color::new_hex("#ff0000ff"), None);
-        engine.append_layer(&child, parent.id);
+        engine.append_layer(&child, parent.id).unwrap();
 
         engine.update(0.016);
         let scene_damage = engine.damage();
@@ -455,13 +455,13 @@ mod tests {
         let parent = engine.new_layer();
         parent.set_position((100.0, 100.0), None);
         parent.set_size(Size::points(300.0, 300.0), None);
-        engine.add_layer(&parent.id);
+        engine.add_layer(&parent.id).unwrap();
 
         let child = engine.new_layer();
         child.set_position((100.0, 100.0), None);
         child.set_size(Size::points(50.0, 50.0), None);
         child.set_background_color(Color::new_hex("#ff0000ff"), None);
-        engine.append_layer(&child, parent.id);
+        engine.append_layer(&child, parent.id).unwrap();
 
         engine.update(0.016);
         engine.clear_damage();
@@ -482,7 +482,7 @@ mod tests {
     pub fn damage_opacity() {
         let engine = Engine::create(1000.0, 1000.0);
         let layer = engine.new_layer();
-        engine.add_layer(&layer);
+        engine.add_layer(&layer).unwrap();
         layer.set_layout_style(layers::taffy::Style {
             position: layers::taffy::Position::Absolute,
             ..Default::default()
@@ -544,7 +544,7 @@ mod tests {
     pub fn damage_animation_updates_scene() {
         let engine = Engine::create(1000.0, 1000.0);
         let layer = engine.new_layer();
-        engine.add_layer(&layer);
+        engine.add_layer(&layer).unwrap();
         layer.set_layout_style(layers::taffy::Style {
             position: layers::taffy::Position::Absolute,
             ..Default::default()
@@ -584,7 +584,7 @@ mod tests {
     pub fn damage_opacity_animation() {
         let engine = Engine::create(1000.0, 1000.0);
         let layer = engine.new_layer();
-        engine.add_layer(&layer);
+        engine.add_layer(&layer).unwrap();
         layer.set_layout_style(layers::taffy::Style {
             position: layers::taffy::Position::Absolute,
             ..Default::default()
@@ -620,7 +620,7 @@ mod tests {
     pub fn damage_size_animation() {
         let engine = Engine::create(1000.0, 1000.0);
         let layer = engine.new_layer();
-        engine.add_layer(&layer);
+        engine.add_layer(&layer).unwrap();
         layer.set_layout_style(layers::taffy::Style {
             position: layers::taffy::Position::Absolute,
             ..Default::default()
@@ -655,7 +655,7 @@ mod tests {
     pub fn damage_layer_removal() {
         let engine = Engine::create(1000.0, 1000.0);
         let root = engine.new_layer();
-        engine.add_layer(&root);
+        engine.add_layer(&root).unwrap();
         root.set_layout_style(layers::taffy::Style {
             position: layers::taffy::Position::Absolute,
             ..Default::default()
@@ -677,7 +677,7 @@ mod tests {
             None,
         );
 
-        engine.append_layer(&child, root.id);
+        engine.append_layer(&child, root.id).unwrap();
 
         engine.update(0.016);
         engine.clear_damage();
@@ -701,7 +701,7 @@ mod tests {
         wrap.set_position((100.0, 100.0), None);
         wrap.set_size(Size::points(0.0, 0.0), None);
 
-        engine.add_layer(&wrap);
+        engine.add_layer(&wrap).unwrap();
 
         let layer = engine.new_layer();
         layer.set_layout_style(layers::taffy::Style {
@@ -712,7 +712,7 @@ mod tests {
         layer.set_size(Size::points(100.0, 100.0), None);
         layer.set_background_color(Color::new_hex("#ff0000ff"), None);
 
-        engine.append_layer(&layer, wrap.id);
+        engine.append_layer(&layer, wrap.id).unwrap();
 
         engine.update(0.016);
         let scene_damage = engine.damage();
@@ -733,7 +733,7 @@ mod tests {
         layer.set_position((100.0, 100.0), None);
         layer.set_size(Size::points(100.0, 100.0), None);
         layer.set_background_color(Color::new_hex("#ff0000ff"), None);
-        engine.add_layer(&layer.id);
+        engine.add_layer(&layer.id).unwrap();
 
         engine.update(0.016);
 
@@ -838,7 +838,7 @@ mod tests {
         });
         container.set_position((100.0, 100.0), None);
         container.set_size(Size::points(200.0, 200.0), None);
-        engine.add_layer(&container.id);
+        engine.add_layer(&container.id).unwrap();
 
         // Child: has background so subtree is visually non-empty
         let child = engine.new_layer();
@@ -849,7 +849,7 @@ mod tests {
         child.set_position((0.0, 0.0), None);
         child.set_size(Size::points(200.0, 200.0), None);
         child.set_background_color(Color::new_hex("#ff0000ff"), None);
-        engine.append_layer(&child.id, Some(container.id));
+        engine.append_layer(&child.id, Some(container.id)).unwrap();
 
         engine.update(0.016);
         engine.clear_damage();
@@ -926,7 +926,7 @@ mod tests {
         // Create an explicit root to hold both leader and follower as siblings
         let root = engine.new_layer();
         root.set_size(Size::points(1000.0, 1000.0), None);
-        engine.add_layer(&root);
+        engine.add_layer(&root).unwrap();
 
         // Leader layer A: at position (0,0), size 100x100
         let leader = engine.new_layer();
@@ -942,7 +942,7 @@ mod tests {
                 skia_safe::Rect::from_xywh(0.0, 0.0, 100.0, 100.0)
             },
         );
-        engine.append_layer(&leader, root.id);
+        engine.append_layer(&leader, root.id).unwrap();
 
         // Initial update to establish leader's state
         engine.update(0.016);
@@ -967,7 +967,7 @@ mod tests {
         leader.add_follower_node(follower.id());
 
         // Add follower as sibling to leader (not child)
-        engine.append_layer(&follower, root.id);
+        engine.append_layer(&follower, root.id).unwrap();
 
         // This update should NOT cause stack overflow anymore
         engine.update(0.016);

--- a/tests/damage.rs
+++ b/tests/damage.rs
@@ -172,13 +172,17 @@ mod tests {
         hidden_parent.set_position((100.0, 100.0), None);
         hidden_parent.set_size(Size::points(300.0, 300.0), None);
         hidden_parent.set_hidden(true);
-        engine.append_layer(&hidden_parent.id, Some(root.id)).unwrap();
+        engine
+            .append_layer(&hidden_parent.id, Some(root.id))
+            .unwrap();
 
         let child = engine.new_layer();
         child.set_position((20.0, 20.0), None);
         child.set_size(Size::points(100.0, 100.0), None);
         child.set_blend_mode(layers::types::BlendMode::BackgroundBlur);
-        engine.append_layer(&child.id, Some(hidden_parent.id)).unwrap();
+        engine
+            .append_layer(&child.id, Some(hidden_parent.id))
+            .unwrap();
 
         engine.update(0.016);
 

--- a/tests/engine.rs
+++ b/tests/engine.rs
@@ -5,7 +5,7 @@ pub fn pending_transactions_count_reflects_scheduled_changes() {
     let engine = Engine::create(1000.0, 1000.0);
 
     let layer = engine.new_layer();
-    engine.add_layer(&layer).unwrap().unwrap();
+    engine.add_layer(&layer).unwrap();
 
     // Before any change is scheduled there should be no pending transactions.
     engine.update(0.016);
@@ -33,7 +33,7 @@ pub fn engine_update() {
 
     layer.add_sublayer(&child_layer).unwrap();
 
-    engine.add_layer(&layer).unwrap().unwrap();
+    engine.add_layer(&layer).unwrap();
 
     engine.update(0.016);
     engine.update(0.016);
@@ -119,7 +119,7 @@ fn removing_layer_subtree_triggers_layout() {
     child.add_sublayer(&grandchild).unwrap();
     root.add_sublayer(&child).unwrap();
 
-    engine.add_layer(&root).unwrap().unwrap();
+    engine.add_layer(&root).unwrap();
 
     // Allow the engine to process the additions so layout nodes exist.
     engine.update(0.016);
@@ -139,7 +139,7 @@ pub fn access_removed_node_does_not_panic() {
 
     let root = engine.new_layer();
     root.set_size(Size::points(500.0, 500.0), None);
-    engine.add_layer(&root).unwrap().unwrap();
+    engine.add_layer(&root).unwrap();
 
     let child = engine.new_layer();
     child.set_size(Size::points(100.0, 100.0), None);

--- a/tests/engine.rs
+++ b/tests/engine.rs
@@ -5,7 +5,7 @@ pub fn pending_transactions_count_reflects_scheduled_changes() {
     let engine = Engine::create(1000.0, 1000.0);
 
     let layer = engine.new_layer();
-    engine.add_layer(&layer);
+    engine.add_layer(&layer).unwrap();
 
     // Before any change is scheduled there should be no pending transactions.
     engine.update(0.016);
@@ -31,9 +31,9 @@ pub fn engine_update() {
     let child_layer = engine.new_layer();
     child_layer.set_size(Size::percent(0.5, 0.5), None);
 
-    layer.add_sublayer(&child_layer);
+    layer.add_sublayer(&child_layer).unwrap();
 
-    engine.add_layer(&layer);
+    engine.add_layer(&layer).unwrap();
 
     engine.update(0.016);
     engine.update(0.016);
@@ -116,10 +116,10 @@ fn removing_layer_subtree_triggers_layout() {
     let grandchild = engine.new_layer();
     grandchild.set_size(Size::points(100.0, 100.0), None);
 
-    child.add_sublayer(&grandchild);
-    root.add_sublayer(&child);
+    child.add_sublayer(&grandchild).unwrap();
+    root.add_sublayer(&child).unwrap();
 
-    engine.add_layer(&root);
+    engine.add_layer(&root).unwrap();
 
     // Allow the engine to process the additions so layout nodes exist.
     engine.update(0.016);
@@ -139,11 +139,11 @@ pub fn access_removed_node_does_not_panic() {
 
     let root = engine.new_layer();
     root.set_size(Size::points(500.0, 500.0), None);
-    engine.add_layer(&root);
+    engine.add_layer(&root).unwrap();
 
     let child = engine.new_layer();
     child.set_size(Size::points(100.0, 100.0), None);
-    root.add_sublayer(&child);
+    root.add_sublayer(&child).unwrap();
 
     engine.update(0.016);
 

--- a/tests/engine.rs
+++ b/tests/engine.rs
@@ -5,7 +5,7 @@ pub fn pending_transactions_count_reflects_scheduled_changes() {
     let engine = Engine::create(1000.0, 1000.0);
 
     let layer = engine.new_layer();
-    engine.add_layer(&layer).unwrap();
+    engine.add_layer(&layer).unwrap().unwrap();
 
     // Before any change is scheduled there should be no pending transactions.
     engine.update(0.016);
@@ -33,7 +33,7 @@ pub fn engine_update() {
 
     layer.add_sublayer(&child_layer).unwrap();
 
-    engine.add_layer(&layer).unwrap();
+    engine.add_layer(&layer).unwrap().unwrap();
 
     engine.update(0.016);
     engine.update(0.016);
@@ -64,8 +64,8 @@ pub fn test_independent_engines() {
     layer2.set_size(Size::points(300.0, 250.0), None);
 
     // Add them to their respective engines
-    engine1.add_layer(&layer1);
-    engine2.add_layer(&layer2);
+    engine1.add_layer(&layer1).unwrap();
+    engine2.add_layer(&layer2).unwrap();
 
     // Update both engines
     engine1.update(0.016);
@@ -119,7 +119,7 @@ fn removing_layer_subtree_triggers_layout() {
     child.add_sublayer(&grandchild).unwrap();
     root.add_sublayer(&child).unwrap();
 
-    engine.add_layer(&root).unwrap();
+    engine.add_layer(&root).unwrap().unwrap();
 
     // Allow the engine to process the additions so layout nodes exist.
     engine.update(0.016);
@@ -139,7 +139,7 @@ pub fn access_removed_node_does_not_panic() {
 
     let root = engine.new_layer();
     root.set_size(Size::points(500.0, 500.0), None);
-    engine.add_layer(&root).unwrap();
+    engine.add_layer(&root).unwrap().unwrap();
 
     let child = engine.new_layer();
     child.set_size(Size::points(100.0, 100.0), None);

--- a/tests/entities.rs
+++ b/tests/entities.rs
@@ -6,7 +6,7 @@ pub fn change_layer_position() {
 
     let layer = engine.new_layer();
 
-    engine.add_layer(&layer);
+    engine.add_layer(&layer).unwrap();
 
     assert_eq!(layer.position().x, 0.0);
 

--- a/tests/image_cache.rs
+++ b/tests/image_cache.rs
@@ -11,7 +11,7 @@ pub fn image_cache() {
 
     let layer = engine.new_layer();
 
-    engine.add_layer(&layer);
+    engine.add_layer(&layer).unwrap();
 
     layer.set_position((50.0, 50.0), None);
     layer.set_size(Size::points(200.0, 200.0), None);
@@ -33,7 +33,7 @@ pub fn image_cache() {
     child_layer.set_border_color(Color::new_hex("#000000"), None);
     child_layer.set_border_width(2.0, None);
 
-    engine.append_layer(&child_layer, Some(layer.id));
+    engine.append_layer(&child_layer, Some(layer.id)).unwrap();
 
     engine.update(0.01);
 

--- a/tests/layer_contains.rs
+++ b/tests/layer_contains.rs
@@ -7,7 +7,7 @@ pub fn layer_contains() {
     let layer = engine.new_layer();
     layer.set_size(Size::points(100.0, 100.0), None);
 
-    engine.add_layer(&layer);
+    engine.add_layer(&layer).unwrap();
 
     engine.update(0.016);
 
@@ -25,7 +25,7 @@ pub fn layer_contains() {
 pub fn scene_node_contains() {
     let engine = Engine::create(1000.0, 1000.0);
     let layer = engine.new_layer();
-    engine.add_layer(&layer);
+    engine.add_layer(&layer).unwrap();
     layer.set_size(Size::points(100.0, 100.0), None);
     layer.set_anchor_point(Point { x: 0.5, y: 0.5 }, None);
     layer.set_position(Point { x: 100.0, y: 100.0 }, None);
@@ -62,7 +62,7 @@ pub fn layer_contains_scale() {
     let layer = engine.new_layer();
     layer.set_size(Size::points(100.0, 100.0), None);
 
-    engine.add_layer(&layer);
+    engine.add_layer(&layer).unwrap();
 
     layer.set_scale(Point { x: 2.0, y: 2.0 }, None);
     engine.update(0.016);

--- a/tests/occlusion_scene.rs
+++ b/tests/occlusion_scene.rs
@@ -240,6 +240,7 @@ fn fetch_scene_json() -> String {
 }
 
 #[test]
+#[ignore = "requires ROOT_NODE, TARGET_NODE, and SCENE_URL/SCENE_FILE env vars plus external curl"]
 fn test_occlusion_for_scene() {
     let root_id: u64 = std::env::var("ROOT_NODE")
         .expect("set ROOT_NODE env var")

--- a/tests/occlusion_scene.rs
+++ b/tests/occlusion_scene.rs
@@ -1,0 +1,307 @@
+//! Integration test for occlusion culling against a live/saved scene.
+//!
+//! Fetches a scene JSON from a local server and tests whether a target node
+//! would be skipped (occluded) or drawn for a given root node.
+//!
+//! # Usage
+//!
+//! ```sh
+//! SCENE_URL=http://localhost:8000/scene/89 \
+//!   ROOT_NODE=89 \
+//!   TARGET_NODE=130 \
+//!   cargo test --test occlusion_scene -- --nocapture
+//! ```
+//!
+//! Or from a saved JSON file:
+//!
+//! ```sh
+//! SCENE_FILE=scene_89.json \
+//!   ROOT_NODE=89 \
+//!   TARGET_NODE=130 \
+//!   cargo test --test occlusion_scene -- --nocapture
+//! ```
+//!
+//! The JSON format matches the output of the layers inspector `/scene/{id}` endpoint:
+//!
+//! ```json
+//! [root_id, {
+//!   "node_id": [node_id, { ...render_layer_props... }, [children_ids], { "index1": N }],
+//!   ...
+//! }]
+//! ```
+
+use std::collections::HashMap;
+
+use indextree::Arena;
+use layers::engine::occlusion::compute_occlusion;
+use layers::engine::{NodeRef, SceneNode};
+use layers::prelude::*;
+
+/// Parsed representation of a scene node from JSON.
+struct ParsedNode {
+    id: u64,
+    hidden: bool,
+    opacity: f32,
+    blend_mode: BlendMode,
+    background_color_alpha: f32,
+    border_corner_radius: BorderRadius,
+    shape_is_roundrect: bool,
+    clip_children: bool,
+    transformed_bounds: skia_safe::Rect,
+    children: Vec<u64>,
+    key: String,
+}
+
+fn parse_scene_json(json_str: &str) -> (u64, Vec<ParsedNode>) {
+    let value: serde_json::Value = serde_json::from_str(json_str).expect("invalid JSON");
+    let arr = value
+        .as_array()
+        .expect("scene JSON must be an array [root_id, nodes_map]");
+
+    let root_id = arr[0].as_u64().expect("root_id must be a number");
+    let nodes_map = arr[1].as_object().expect("nodes_map must be an object");
+
+    let mut parsed_nodes = Vec::new();
+
+    for (_key, node_value) in nodes_map {
+        let node_arr = node_value
+            .as_array()
+            .expect("each node must be [id, props, children, index]");
+        let node_id = node_arr[0].as_u64().expect("node id must be a number");
+        let props = &node_arr[1];
+        let children_arr = node_arr[2].as_array().expect("children must be an array");
+        let children: Vec<u64> = children_arr.iter().map(|c| c.as_u64().unwrap()).collect();
+
+        let hidden = props["hidden"].as_bool().unwrap_or(false);
+        let opacity = props["opacity"].as_f64().unwrap_or(1.0) as f32;
+
+        let blend_mode = match props["blend_mode"].as_str().unwrap_or("Normal") {
+            "BackgroundBlur" => BlendMode::BackgroundBlur,
+            _ => BlendMode::Normal,
+        };
+
+        // Extract alpha from background_color (supports Solid only for now)
+        let background_color_alpha = props
+            .get("background_color")
+            .and_then(|bg| bg.get("Solid"))
+            .and_then(|solid| solid.get("color"))
+            .and_then(|color| color.get("alpha"))
+            .and_then(|a| a.as_f64())
+            .unwrap_or(0.0) as f32;
+
+        let bcr = &props["border_corner_radius"];
+        let border_corner_radius = BorderRadius {
+            top_left: bcr["top_left"].as_f64().unwrap_or(0.0) as f32,
+            top_right: bcr["top_right"].as_f64().unwrap_or(0.0) as f32,
+            bottom_right: bcr["bottom_right"].as_f64().unwrap_or(0.0) as f32,
+            bottom_left: bcr["bottom_left"].as_f64().unwrap_or(0.0) as f32,
+        };
+
+        let shape_is_roundrect = match &props["shape"] {
+            serde_json::Value::String(s) => s == "RoundRect",
+            _ => false, // Path or other custom shapes
+        };
+
+        // Use "transformed_bounds" as the global bounds
+        let tb = &props["transformed_bounds"];
+        let x = tb["x"].as_f64().unwrap_or(0.0) as f32;
+        let y = tb["y"].as_f64().unwrap_or(0.0) as f32;
+        let w = tb["width"].as_f64().unwrap_or(0.0) as f32;
+        let h = tb["height"].as_f64().unwrap_or(0.0) as f32;
+        let transformed_bounds = skia_safe::Rect::from_xywh(x, y, w, h);
+
+        let clip_children = false; // Not present in JSON — inspect manually if needed
+
+        let key = props["key"].as_str().unwrap_or("").to_string();
+
+        parsed_nodes.push(ParsedNode {
+            id: node_id,
+            hidden,
+            opacity,
+            blend_mode,
+            background_color_alpha,
+            border_corner_radius,
+            shape_is_roundrect,
+            clip_children,
+            transformed_bounds,
+            children,
+            key,
+        });
+    }
+
+    (root_id, parsed_nodes)
+}
+
+/// Build an indextree arena from parsed nodes, returning the root NodeRef
+/// and a mapping from scene node IDs to arena NodeIds.
+fn build_arena(
+    root_id: u64,
+    parsed_nodes: &[ParsedNode],
+) -> (Arena<SceneNode>, NodeRef, HashMap<u64, indextree::NodeId>) {
+    let mut arena = Arena::<SceneNode>::new();
+    let mut id_map: HashMap<u64, indextree::NodeId> = HashMap::new();
+
+    // First pass: create all arena nodes
+    for pn in parsed_nodes {
+        let mut scene_node = SceneNode::default();
+        scene_node.set_hidden(pn.hidden);
+
+        let rl = scene_node.render_layer_mut();
+        rl.key = pn.key.clone();
+        rl.opacity = pn.opacity;
+        rl.premultiplied_opacity = pn.opacity; // will be fixed in second pass
+        rl.blend_mode = pn.blend_mode;
+        rl.global_transformed_bounds = pn.transformed_bounds;
+        rl.border_corner_radius = pn.border_corner_radius;
+        rl.clip_children = pn.clip_children;
+
+        if pn.shape_is_roundrect {
+            rl.shape = Shape::RoundRect;
+        }
+        // else it keeps default (which should be RoundRect from Default impl)
+
+        // Set background_color alpha
+        rl.background_color = PaintColor::Solid {
+            color: Color {
+                l: 0.0,
+                a: 0.0,
+                b: 0.0,
+                alpha: pn.background_color_alpha,
+            },
+        };
+
+        let node_id = arena.new_node(scene_node);
+        id_map.insert(pn.id, node_id);
+    }
+
+    // Second pass: build parent-child hierarchy
+    for pn in parsed_nodes {
+        if let Some(&parent_arena_id) = id_map.get(&pn.id) {
+            for &child_scene_id in &pn.children {
+                if let Some(&child_arena_id) = id_map.get(&child_scene_id) {
+                    parent_arena_id.append(child_arena_id, &mut arena);
+                }
+            }
+        }
+    }
+
+    // Third pass: compute premultiplied_opacity by walking from root
+    let root_arena_id = *id_map
+        .get(&root_id)
+        .expect("root_id not found in parsed nodes");
+    propagate_opacity(root_arena_id, 1.0, &mut arena);
+
+    let root_ref = NodeRef(root_arena_id);
+    (arena, root_ref, id_map)
+}
+
+fn propagate_opacity(
+    node_id: indextree::NodeId,
+    parent_opacity: f32,
+    arena: &mut Arena<SceneNode>,
+) {
+    let node_opacity = arena.get(node_id).unwrap().get().render_layer().opacity;
+    let premultiplied = node_opacity * parent_opacity;
+    arena
+        .get_mut(node_id)
+        .unwrap()
+        .get_mut()
+        .render_layer_mut()
+        .premultiplied_opacity = premultiplied;
+
+    let children: Vec<_> = node_id.children(arena).collect();
+    for child_id in children {
+        propagate_opacity(child_id, premultiplied, arena);
+    }
+}
+
+fn fetch_scene_json() -> String {
+    if let Ok(file_path) = std::env::var("SCENE_FILE") {
+        return std::fs::read_to_string(&file_path)
+            .unwrap_or_else(|e| panic!("failed to read {}: {}", file_path, e));
+    }
+
+    if let Ok(url) = std::env::var("SCENE_URL") {
+        let output = std::process::Command::new("curl")
+            .args(["-s", "--fail", &url])
+            .output()
+            .expect("failed to execute curl");
+        if !output.status.success() {
+            panic!(
+                "curl failed with status {}: {}",
+                output.status,
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+        return String::from_utf8(output.stdout).expect("invalid UTF-8 from curl");
+    }
+
+    panic!("set either SCENE_URL or SCENE_FILE environment variable");
+}
+
+#[test]
+fn test_occlusion_for_scene() {
+    let root_id: u64 = std::env::var("ROOT_NODE")
+        .expect("set ROOT_NODE env var")
+        .parse()
+        .expect("ROOT_NODE must be a number");
+    let target_id: u64 = std::env::var("TARGET_NODE")
+        .expect("set TARGET_NODE env var")
+        .parse()
+        .expect("TARGET_NODE must be a number");
+
+    let json_str = fetch_scene_json();
+    let (scene_root_id, parsed_nodes) = parse_scene_json(&json_str);
+
+    eprintln!("Scene root: {}", scene_root_id);
+    eprintln!("Nodes parsed: {}", parsed_nodes.len());
+    eprintln!("Using root: {}, target: {}", root_id, target_id);
+
+    let (arena, root_ref, id_map) = build_arena(root_id, &parsed_nodes);
+
+    let occluded = compute_occlusion(root_ref, &arena);
+
+    let target_arena_id = id_map
+        .get(&target_id)
+        .unwrap_or_else(|| panic!("target node {} not found in scene", target_id));
+    let target_ref = NodeRef(*target_arena_id);
+
+    let is_occluded = occluded.contains(&target_ref);
+
+    // Print all occluded nodes for debugging
+    eprintln!("\n--- Occlusion Results ---");
+    eprintln!("Total occluded nodes: {}", occluded.len());
+
+    // Reverse-map arena IDs to scene IDs for readable output
+    let arena_to_scene: HashMap<indextree::NodeId, u64> =
+        id_map.iter().map(|(&sid, &aid)| (aid, sid)).collect();
+
+    for occ_ref in &occluded {
+        let arena_id: indextree::NodeId = (*occ_ref).into();
+        let scene_id = arena_to_scene.get(&arena_id).unwrap_or(&0);
+        let key = arena
+            .get(arena_id)
+            .map(|n| n.get().render_layer().key.clone())
+            .unwrap_or_default();
+        eprintln!("  occluded: node {} (key: {})", scene_id, key);
+    }
+
+    // Print target node info
+    let target_node = arena.get(*target_arena_id).unwrap().get();
+    let target_rl = target_node.render_layer();
+    eprintln!("\n--- Target Node {} ---", target_id);
+    eprintln!("  key: {}", target_rl.key);
+    eprintln!("  hidden: {}", target_node.hidden());
+    eprintln!("  opacity: {}", target_rl.opacity);
+    eprintln!(
+        "  premultiplied_opacity: {}",
+        target_rl.premultiplied_opacity
+    );
+    eprintln!("  bounds: {:?}", target_rl.global_transformed_bounds);
+    eprintln!("  is_fully_opaque: {}", target_rl.is_fully_opaque());
+    eprintln!(
+        "\n  RESULT: node {} will be {}",
+        target_id,
+        if is_occluded { "SKIPPED" } else { "DRAWN" }
+    );
+}

--- a/tests/opacity.rs
+++ b/tests/opacity.rs
@@ -7,7 +7,7 @@ mod tests {
         let engine = Engine::create(1000.0, 1000.0);
 
         let layer = engine.new_layer();
-        engine.add_layer(&layer);
+        engine.add_layer(&layer).unwrap();
 
         layer.set_opacity(0.0, None);
         engine.update(0.016);

--- a/tests/par_iter.rs
+++ b/tests/par_iter.rs
@@ -54,7 +54,7 @@ mod tests {
         let mut layers = Vec::<Layer>::new();
         for _ in 0..1000 {
             let layer = engine.new_layer();
-            engine.add_layer(&layer);
+            engine.add_layer(&layer).unwrap();
             layers.push(layer);
         }
 
@@ -105,7 +105,7 @@ mod tests {
             layer.set_background_color(Color::new_rgba(1.0, 0.0, 0.0, 1.0), None);
             let i = i as f32;
             layer.set_position((i * 10.0, i * 10.0), None);
-            engine.add_layer(&layer);
+            engine.add_layer(&layer).unwrap();
             layers.push(layer);
         }
 

--- a/tests/pointer_handlers.rs
+++ b/tests/pointer_handlers.rs
@@ -10,7 +10,7 @@ pub fn pointer_move() {
     let layer = engine.new_layer();
     layer.set_size(Size::points(200.0, 200.0), None);
     layer.set_position((0.0, 0.0), None);
-    engine.add_layer(&layer);
+    engine.add_layer(&layer).unwrap();
 
     engine.update(0.016);
     let called = Arc::new(RwLock::new(0));
@@ -35,7 +35,7 @@ pub fn pointer_doesnt_move() {
     let layer = engine.new_layer();
     layer.set_size(Size::points(200.0, 200.0), None);
     layer.set_position((200.0, 200.0), None);
-    engine.add_layer(&layer);
+    engine.add_layer(&layer).unwrap();
     engine.update(0.016);
 
     let called = Arc::new(RwLock::new(0));
@@ -60,12 +60,12 @@ pub fn pointer_move_nested() {
     let layer = engine.new_layer();
     layer.set_size(Size::points(200.0, 200.0), None);
     layer.set_position((200.0, 200.0), None);
-    engine.add_layer(&layer);
+    engine.add_layer(&layer).unwrap();
 
     let layer2 = engine.new_layer();
     layer2.set_size(Size::points(200.0, 200.0), None);
     layer2.set_position((200.0, 200.0), None);
-    engine.append_layer(&layer2, layer.id);
+    engine.append_layer(&layer2, layer.id).unwrap();
 
     engine.update(0.016);
 
@@ -92,12 +92,12 @@ pub fn pointer_move_nested_parent() {
     let layer = engine.new_layer();
     layer.set_size(Size::points(200.0, 200.0), None);
     layer.set_position((200.0, 200.0), None);
-    engine.add_layer(&layer);
+    engine.add_layer(&layer).unwrap();
 
     let layer2 = engine.new_layer();
     layer2.set_size(Size::points(200.0, 200.0), None);
     layer2.set_position((200.0, 200.0), None);
-    engine.append_layer(&layer2, layer.id);
+    engine.append_layer(&layer2, layer.id).unwrap();
 
     engine.update(0.016);
 
@@ -123,12 +123,12 @@ pub fn pointer_doesnt_move_nested() {
     let layer = engine.new_layer();
     layer.set_size(Size::points(200.0, 200.0), None);
     layer.set_position((200.0, 200.0), None);
-    engine.add_layer(&layer);
+    engine.add_layer(&layer).unwrap();
 
     let layer2 = engine.new_layer();
     layer2.set_size(Size::points(200.0, 200.0), None);
     layer2.set_position((200.0, 200.0), None);
-    engine.append_layer(&layer2, layer.id);
+    engine.append_layer(&layer2, layer.id).unwrap();
 
     engine.update(0.016);
 
@@ -156,7 +156,7 @@ pub fn pointer_remove() {
     layer.set_size(Size::points(200.0, 200.0), None);
     layer.set_position((0.0, 0.0), None);
 
-    engine.add_layer(&layer);
+    engine.add_layer(&layer).unwrap();
 
     engine.update(0.016);
     let called = Arc::new(RwLock::new(0));
@@ -184,12 +184,12 @@ pub fn pointer_in_out_nested_parent() {
     let layer = engine.new_layer();
     layer.set_size(Size::points(200.0, 200.0), None);
     layer.set_position((200.0, 200.0), None);
-    engine.add_layer(&layer);
+    engine.add_layer(&layer).unwrap();
 
     let layer2 = engine.new_layer();
     layer2.set_size(Size::points(200.0, 200.0), None);
     layer2.set_position((200.0, 200.0), None);
-    engine.append_layer(&layer2, layer.id);
+    engine.append_layer(&layer2, layer.id).unwrap();
 
     engine.update(0.016);
 
@@ -236,13 +236,13 @@ pub fn pointer_hidden_parent_excludes_children() {
     let parent = engine.new_layer();
     parent.set_size(Size::points(400.0, 400.0), None);
     parent.set_position((0.0, 0.0), None);
-    engine.add_layer(&parent);
+    engine.add_layer(&parent).unwrap();
 
     // Create child layer inside the parent
     let child = engine.new_layer();
     child.set_size(Size::points(100.0, 100.0), None);
     child.set_position((50.0, 50.0), None);
-    engine.append_layer(&child, parent.id);
+    engine.append_layer(&child, parent.id).unwrap();
 
     engine.update(0.016);
 

--- a/tests/render_layer.rs
+++ b/tests/render_layer.rs
@@ -9,7 +9,7 @@ mod tests {
     pub fn render_layer_size() {
         let engine = Engine::create(1000.0, 1000.0);
         let layer = engine.new_layer();
-        engine.add_layer(&layer);
+        engine.add_layer(&layer).unwrap();
 
         let _tr = layer.set_size(Size::points(100.0, 100.0), None);
 
@@ -31,7 +31,7 @@ mod tests {
         let engine = Engine::create(1000.0, 1000.0);
         let layer = engine.new_layer();
 
-        engine.append_layer(&layer, None);
+        engine.append_layer(&layer, None).unwrap();
 
         layer.set_position((100.0, 100.0), None);
 
@@ -49,7 +49,7 @@ mod tests {
     pub fn anchor_point_change_preserves_position() {
         let engine = Engine::create(800.0, 600.0);
         let layer = engine.new_layer();
-        engine.add_layer(&layer);
+        engine.add_layer(&layer).unwrap();
 
         layer.set_size(Size::points(200.0, 100.0), None);
         layer.set_position((50.0, 80.0), None);
@@ -73,7 +73,7 @@ mod tests {
     pub fn anchor_point_change_with_scale_preserves_position() {
         let engine = Engine::create(800.0, 600.0);
         let layer = engine.new_layer();
-        engine.add_layer(&layer);
+        engine.add_layer(&layer).unwrap();
 
         layer.set_size(Size::points(200.0, 100.0), None);
         layer.set_position((50.0, 80.0), None);
@@ -99,7 +99,7 @@ mod tests {
         let engine = Engine::create(1000.0, 1000.0);
         let layer = engine.new_layer();
 
-        engine.append_layer(&layer.id, None);
+        engine.append_layer(&layer.id, None).unwrap();
 
         layer.set_background_color(Color::new_hex("#ff0000ff"), None);
 
@@ -119,7 +119,7 @@ mod tests {
     pub fn render_layer_bounds_and_transforms() {
         let engine = Engine::create(1000.0, 1000.0);
         let layer = engine.new_layer();
-        engine.add_layer(&layer);
+        engine.add_layer(&layer).unwrap();
 
         layer.set_size(Size::points(100.0, 50.0), None);
         layer.set_position((10.0, 20.0), None);
@@ -152,7 +152,7 @@ mod tests {
         // Parent
         let parent = engine.new_layer();
         parent.set_size(Size::points(100.0, 100.0), None);
-        engine.add_layer(&parent);
+        engine.add_layer(&parent).unwrap();
 
         // Child extends beyond parent on right/bottom to test union
         let child = engine.new_layer();
@@ -160,7 +160,7 @@ mod tests {
         child.set_size(Size::points(50.0, 50.0), None);
         // Give the child a background so it contributes damage/bounds
         child.set_background_color(Color::new_hex("#ff0000ff"), None);
-        engine.append_layer(&child, parent.id);
+        engine.append_layer(&child, parent.id).unwrap();
 
         engine.update(0.016);
 
@@ -193,14 +193,14 @@ mod tests {
         let parent = engine.new_layer();
         parent.set_position((10.0, 20.0), None);
         parent.set_size(Size::points(100.0, 100.0), None);
-        engine.add_layer(&parent);
+        engine.add_layer(&parent).unwrap();
 
         // Child within parent
         let child = engine.new_layer();
         child.set_position((70.0, 80.0), None);
         child.set_size(Size::points(50.0, 50.0), None);
         child.set_background_color(Color::new_hex("#00ff00ff"), None);
-        engine.append_layer(&child, parent.id);
+        engine.append_layer(&child, parent.id).unwrap();
 
         engine.update(0.016);
 
@@ -231,20 +231,20 @@ mod tests {
         let gp = engine.new_layer();
         gp.set_position((5.0, 6.0), None);
         gp.set_size(Size::points(100.0, 100.0), None);
-        engine.add_layer(&gp);
+        engine.add_layer(&gp).unwrap();
 
         // Parent at an additional offset (relative to grandparent)
         let parent = engine.new_layer();
         parent.set_position((10.0, 20.0), None);
         parent.set_size(Size::points(80.0, 80.0), None);
-        engine.append_layer(&parent, gp.id);
+        engine.append_layer(&parent, gp.id).unwrap();
 
         // Child extends beyond parent (relative to parent)
         let child = engine.new_layer();
         child.set_position((70.0, 80.0), None);
         child.set_size(Size::points(50.0, 50.0), None);
         child.set_background_color(Color::new_hex("#0000ffff"), None);
-        engine.append_layer(&child, parent.id);
+        engine.append_layer(&child, parent.id).unwrap();
 
         engine.update(0.016);
 
@@ -283,7 +283,7 @@ mod tests {
         // Parent at origin with a base size
         let parent = engine.new_layer();
         parent.set_size(Size::points(100.0, 100.0), None);
-        engine.add_layer(&parent);
+        engine.add_layer(&parent).unwrap();
 
         // Child initially fully inside the parent
         let child = engine.new_layer();
@@ -291,7 +291,7 @@ mod tests {
         child.set_size(Size::points(40.0, 40.0), None);
         // Give the child a background so it contributes to bounds
         child.set_background_color(Color::new_hex("#ff00ffff"), None);
-        engine.append_layer(&child, parent.id);
+        engine.append_layer(&child, parent.id).unwrap();
 
         // Initial update
         engine.update(0.016);
@@ -324,14 +324,14 @@ mod tests {
         // Parent at origin 500x500
         let parent = engine.new_layer();
         parent.set_size(Size::points(500.0, 500.0), None);
-        engine.add_layer(&parent);
+        engine.add_layer(&parent).unwrap();
 
         // Child extends beyond parent on left/top and right/bottom
         let child = engine.new_layer();
         child.set_position((-100.0, -100.0), None);
         child.set_size(Size::points(700.0, 700.0), None);
         child.set_background_color(Color::new_hex("#112233ff"), None);
-        engine.append_layer(&child, parent.id);
+        engine.append_layer(&child, parent.id).unwrap();
 
         engine.update(0.016);
 
@@ -356,21 +356,21 @@ mod tests {
         // Parent at origin 100x100
         let parent = engine.new_layer();
         parent.set_size(Size::points(100.0, 100.0), None);
-        engine.add_layer(&parent);
+        engine.add_layer(&parent).unwrap();
 
         // Child A extends to the left/top slightly
         let child_a = engine.new_layer();
         child_a.set_position((-20.0, -30.0), None);
         child_a.set_size(Size::points(40.0, 50.0), None);
         child_a.set_background_color(Color::new_hex("#abcdefFF"), None);
-        engine.append_layer(&child_a, parent.id);
+        engine.append_layer(&child_a, parent.id).unwrap();
 
         // Child B extends to the right/bottom beyond parent
         let child_b = engine.new_layer();
         child_b.set_position((120.0, 140.0), None);
         child_b.set_size(Size::points(80.0, 30.0), None);
         child_b.set_background_color(Color::new_hex("#fedcbaFF"), None);
-        engine.append_layer(&child_b, parent.id);
+        engine.append_layer(&child_b, parent.id).unwrap();
 
         engine.update(0.016);
 
@@ -394,14 +394,14 @@ mod tests {
 
         let parent = engine.new_layer();
         parent.set_size(Size::points(300.0, 300.0), None);
-        engine.add_layer(&parent);
+        engine.add_layer(&parent).unwrap();
 
         let child = engine.new_layer();
         child.set_position((250.0, 250.0), None);
         child.set_size(Size::points(100.0, 100.0), None);
         child.set_background_color(Color::new_hex("#00ff00ff"), None);
         child.set_image_cached(true);
-        engine.append_layer(&child, parent.id);
+        engine.append_layer(&child, parent.id).unwrap();
 
         engine.update(0.016);
 

--- a/tests/render_list.rs
+++ b/tests/render_list.rs
@@ -11,13 +11,13 @@ mod tests {
         let engine = Engine::create(1000.0, 1000.0);
 
         let layer = engine.new_layer();
-        engine.add_layer(&layer);
+        engine.add_layer(&layer).unwrap();
 
         let layer = engine.new_layer();
-        engine.add_layer(&layer);
+        engine.add_layer(&layer).unwrap();
 
         let layer = engine.new_layer();
-        engine.add_layer(&layer);
+        engine.add_layer(&layer).unwrap();
 
         engine.update(0.016);
 
@@ -34,19 +34,19 @@ mod tests {
         layer.set_position((0.0, 0.0), None);
         layer.set_size(Size::points(100.0, 100.0), None);
 
-        engine.add_layer(&layer);
+        engine.add_layer(&layer).unwrap();
 
         let layer = engine.new_layer();
         layer.set_position((0.0, 0.0), None);
         layer.set_size(Size::points(100.0, 100.0), None);
         layer.set_opacity(0.9, None);
-        engine.add_layer(&layer);
+        engine.add_layer(&layer).unwrap();
 
         let layer = engine.new_layer();
         layer.set_position((0.0, 0.0), None);
         layer.set_size(Size::points(150.0, 150.0), None);
         layer.set_blend_mode(layers::prelude::BlendMode::BackgroundBlur);
-        engine.add_layer(&layer);
+        engine.add_layer(&layer).unwrap();
 
         engine.update(0.016);
 
@@ -65,19 +65,19 @@ mod tests {
         layer.set_position((0.0, 0.0), None);
         layer.set_size(Size::points(100.0, 100.0), None);
 
-        engine.add_layer(&layer);
+        engine.add_layer(&layer).unwrap();
 
         let layer = engine.new_layer();
         layer.set_position((0.0, 0.0), None);
         layer.set_size(Size::points(50.0, 50.0), None);
         layer.set_opacity(1.0, None);
-        engine.add_layer(&layer);
+        engine.add_layer(&layer).unwrap();
 
         let layer = engine.new_layer();
         layer.set_position((0.0, 0.0), None);
         layer.set_size(Size::points(150.0, 150.0), None);
         layer.set_opacity(0.9, None);
-        engine.add_layer(&layer);
+        engine.add_layer(&layer).unwrap();
 
         engine.update(0.016);
 
@@ -96,20 +96,20 @@ mod tests {
         layer.set_position((0.0, 0.0), None);
         layer.set_size(Size::points(100.0, 100.0), None);
 
-        engine.add_layer(&layer);
+        engine.add_layer(&layer).unwrap();
 
         let layer = engine.new_layer();
         layer.set_position((0.0, 0.0), None);
         layer.set_size(Size::points(100.0, 100.0), None);
         layer.set_opacity(0.0, None);
-        engine.add_layer(&layer);
+        engine.add_layer(&layer).unwrap();
 
         let layer = engine.new_layer();
         layer.set_position((0.0, 0.0), None);
         layer.set_size(Size::points(150.0, 150.0), None);
         layer.set_blend_mode(layers::prelude::BlendMode::BackgroundBlur);
         layer.set_hidden(true);
-        engine.add_layer(&layer);
+        engine.add_layer(&layer).unwrap();
 
         engine.update(0.016);
 
@@ -129,14 +129,14 @@ mod tests {
         back.set_position((0.0, 0.0), None);
         back.set_size(Size::points(100.0, 100.0), None);
         back.set_background_color(Color::new_rgba(1.0, 0.0, 0.0, 1.0), None);
-        engine.add_layer(&back);
+        engine.add_layer(&back).unwrap();
 
         // Front layer: opaque, fully covers back
         let front = engine.new_layer();
         front.set_position((0.0, 0.0), None);
         front.set_size(Size::points(200.0, 200.0), None);
         front.set_background_color(Color::new_rgba(0.0, 0.0, 1.0, 1.0), None);
-        engine.add_layer(&front);
+        engine.add_layer(&front).unwrap();
 
         engine.update(0.016);
         engine.clear_occlusion();
@@ -159,13 +159,13 @@ mod tests {
         left.set_position((0.0, 0.0), None);
         left.set_size(Size::points(100.0, 100.0), None);
         left.set_background_color(Color::new_rgba(1.0, 0.0, 0.0, 1.0), None);
-        engine.add_layer(&left);
+        engine.add_layer(&left).unwrap();
 
         let right = engine.new_layer();
         right.set_position((200.0, 0.0), None);
         right.set_size(Size::points(100.0, 100.0), None);
         right.set_background_color(Color::new_rgba(0.0, 0.0, 1.0, 1.0), None);
-        engine.add_layer(&right);
+        engine.add_layer(&right).unwrap();
 
         engine.update(0.016);
         engine.clear_occlusion();
@@ -193,7 +193,7 @@ mod tests {
         back.set_position((0.0, 0.0), None);
         back.set_size(Size::points(100.0, 100.0), None);
         back.set_background_color(Color::new_rgba(1.0, 0.0, 0.0, 1.0), None);
-        engine.add_layer(&back);
+        engine.add_layer(&back).unwrap();
 
         // Front layer has opacity < 1, so it cannot occlude
         let front = engine.new_layer();
@@ -201,7 +201,7 @@ mod tests {
         front.set_size(Size::points(200.0, 200.0), None);
         front.set_background_color(Color::new_rgba(0.0, 0.0, 1.0, 1.0), None);
         front.set_opacity(0.5, None);
-        engine.add_layer(&front);
+        engine.add_layer(&front).unwrap();
 
         engine.update(0.016);
         engine.clear_occlusion();
@@ -225,7 +225,7 @@ mod tests {
         back.set_position((0.0, 0.0), None);
         back.set_size(Size::points(100.0, 100.0), None);
         back.set_background_color(Color::new_rgba(1.0, 0.0, 0.0, 1.0), None);
-        engine.add_layer(&back);
+        engine.add_layer(&back).unwrap();
 
         // Front layer is opaque but has rounded corners
         let front = engine.new_layer();
@@ -233,7 +233,7 @@ mod tests {
         front.set_size(Size::points(200.0, 200.0), None);
         front.set_background_color(Color::new_rgba(0.0, 0.0, 1.0, 1.0), None);
         front.set_border_corner_radius(BorderRadius::new_single(10.0), None);
-        engine.add_layer(&front);
+        engine.add_layer(&front).unwrap();
 
         engine.update(0.016);
         engine.clear_occlusion();
@@ -258,7 +258,7 @@ mod tests {
         parent.set_size(Size::points(100.0, 100.0), None);
         parent.set_clip_children(true, None);
         parent.set_background_color(Color::new_rgba(1.0, 1.0, 1.0, 1.0), None);
-        engine.add_layer(&parent);
+        engine.add_layer(&parent).unwrap();
 
         // Child fully outside the parent clip (absolute positioned at 200,200)
         let child = engine.new_layer();
@@ -269,7 +269,7 @@ mod tests {
         child.set_position((200.0, 200.0), None);
         child.set_size(Size::points(50.0, 50.0), None);
         child.set_background_color(Color::new_rgba(1.0, 0.0, 0.0, 1.0), None);
-        parent.add_sublayer(&child);
+        parent.add_sublayer(&child).unwrap();
 
         engine.update(0.016);
         engine.clear_occlusion();
@@ -294,14 +294,14 @@ mod tests {
         behind.set_position((0.0, 0.0), None);
         behind.set_size(Size::points(200.0, 200.0), None);
         behind.set_background_color(Color::new_rgba(1.0, 0.0, 0.0, 1.0), None);
-        engine.add_layer(&behind);
+        engine.add_layer(&behind).unwrap();
 
         // Parent with clip_children, sized 50x50 (smaller than behind)
         let parent = engine.new_layer();
         parent.set_position((0.0, 0.0), None);
         parent.set_size(Size::points(50.0, 50.0), None);
         parent.set_clip_children(true, None);
-        engine.add_layer(&parent);
+        engine.add_layer(&parent).unwrap();
 
         // Opaque child at 100x100 — extends beyond parent clip (50x50)
         // Only the clipped portion (50x50) should count as occluder
@@ -309,7 +309,7 @@ mod tests {
         child.set_position((0.0, 0.0), None);
         child.set_size(Size::points(100.0, 100.0), None);
         child.set_background_color(Color::new_rgba(0.0, 0.0, 1.0, 1.0), None);
-        parent.add_sublayer(&child);
+        parent.add_sublayer(&child).unwrap();
 
         engine.update(0.016);
         engine.clear_occlusion();
@@ -336,14 +336,14 @@ mod tests {
         blur.set_position((0.0, 0.0), None);
         blur.set_size(Size::points(100.0, 100.0), None);
         blur.set_blend_mode(BlendMode::BackgroundBlur);
-        engine.add_layer(&blur);
+        engine.add_layer(&blur).unwrap();
 
         // Opaque front layer
         let front = engine.new_layer();
         front.set_position((0.0, 0.0), None);
         front.set_size(Size::points(200.0, 200.0), None);
         front.set_background_color(Color::new_rgba(0.0, 0.0, 1.0, 1.0), None);
-        engine.add_layer(&front);
+        engine.add_layer(&front).unwrap();
 
         engine.update(0.016);
         engine.clear_occlusion();
@@ -372,14 +372,14 @@ mod tests {
         back.set_position((0.0, 0.0), None);
         back.set_size(Size::points(100.0, 100.0), None);
         back.set_background_color(Color::new_rgba(1.0, 0.0, 0.0, 1.0), None);
-        engine.add_layer(&back);
+        engine.add_layer(&back).unwrap();
 
         // Semi-transparent parent (opacity 0.9) — entire subtree cannot occlude
         let parent = engine.new_layer();
         parent.set_position((0.0, 0.0), None);
         parent.set_size(Size::points(200.0, 200.0), None);
         parent.set_opacity(0.9, None);
-        engine.add_layer(&parent);
+        engine.add_layer(&parent).unwrap();
 
         // Child with opaque background — but parent opacity < 1.0,
         // so this child must NOT act as an occluder
@@ -387,7 +387,7 @@ mod tests {
         child.set_position((0.0, 0.0), None);
         child.set_size(Size::points(200.0, 200.0), None);
         child.set_background_color(Color::new_rgba(0.0, 0.0, 1.0, 1.0), None);
-        parent.add_sublayer(&child);
+        parent.add_sublayer(&child).unwrap();
 
         engine.update(0.016);
         engine.clear_occlusion();
@@ -412,21 +412,21 @@ mod tests {
         back.set_position((0.0, 0.0), None);
         back.set_size(Size::points(100.0, 100.0), None);
         back.set_background_color(Color::new_rgba(1.0, 0.0, 0.0, 1.0), None);
-        engine.add_layer(&back);
+        engine.add_layer(&back).unwrap();
 
         // Hidden parent — entire subtree should be ignored
         let parent = engine.new_layer();
         parent.set_position((0.0, 0.0), None);
         parent.set_size(Size::points(200.0, 200.0), None);
         parent.set_hidden(true);
-        engine.add_layer(&parent);
+        engine.add_layer(&parent).unwrap();
 
         // Opaque child inside hidden parent — must not occlude anything
         let child = engine.new_layer();
         child.set_position((0.0, 0.0), None);
         child.set_size(Size::points(200.0, 200.0), None);
         child.set_background_color(Color::new_rgba(0.0, 0.0, 1.0, 1.0), None);
-        parent.add_sublayer(&child);
+        parent.add_sublayer(&child).unwrap();
 
         engine.update(0.016);
         engine.clear_occlusion();
@@ -453,7 +453,7 @@ mod tests {
         back.set_position((0.0, 0.0), None);
         back.set_size(Size::points(200.0, 200.0), None);
         back.set_background_color(Color::new_rgba(1.0, 0.0, 0.0, 1.0), None);
-        engine.add_layer(&back);
+        engine.add_layer(&back).unwrap();
 
         // Front layer — transparent background but content declared opaque
         let front = engine.new_layer();
@@ -461,7 +461,7 @@ mod tests {
         front.set_size(Size::points(200.0, 200.0), None);
         // background is transparent (default)
         front.set_content_opaque(true);
-        engine.add_layer(&front);
+        engine.add_layer(&front).unwrap();
 
         engine.update(0.016);
         engine.clear_occlusion();
@@ -487,13 +487,13 @@ mod tests {
         back.set_position((0.0, 0.0), None);
         back.set_size(Size::points(200.0, 200.0), None);
         back.set_background_color(Color::new_rgba(1.0, 0.0, 0.0, 1.0), None);
-        engine.add_layer(&back);
+        engine.add_layer(&back).unwrap();
 
         let front = engine.new_layer();
         front.set_position((0.0, 0.0), None);
         front.set_size(Size::points(200.0, 200.0), None);
         // transparent background and content_opaque not set (default false)
-        engine.add_layer(&front);
+        engine.add_layer(&front).unwrap();
 
         engine.update(0.016);
         engine.clear_occlusion();

--- a/tests/render_list.rs
+++ b/tests/render_list.rs
@@ -120,36 +120,392 @@ mod tests {
             assert_eq!(nodes.len(), 1);
         });
     }
-    // FIXME: review occluded iterator
-    // #[test]
-    // pub fn render_list_occluded() {
-    //     let engine = Engine::create(1000.0, 1000.0);
+    #[test]
+    pub fn occlusion_fully_covered() {
+        let engine = Engine::create(1000.0, 1000.0);
 
-    //     let layer = engine.new_layer();
-    //     layer.set_position((0.0, 0.0), None);
-    //     layer.set_size(Size::points(100.0, 100.0), None);
+        // Back layer: fully covered by front layer
+        let back = engine.new_layer();
+        back.set_position((0.0, 0.0), None);
+        back.set_size(Size::points(100.0, 100.0), None);
+        back.set_background_color(Color::new_rgba(1.0, 0.0, 0.0, 1.0), None);
+        engine.add_layer(&back);
 
-    //     engine.add_layer(&layer);
+        // Front layer: opaque, fully covers back
+        let front = engine.new_layer();
+        front.set_position((0.0, 0.0), None);
+        front.set_size(Size::points(200.0, 200.0), None);
+        front.set_background_color(Color::new_rgba(0.0, 0.0, 1.0, 1.0), None);
+        engine.add_layer(&front);
 
-    //     let layer = engine.new_layer();
-    //     layer.set_position((100.0, 100.0), None);
-    //     layer.set_size(Size::points(100.0, 100.0), None);
+        engine.update(0.016);
+        engine.clear_occlusion();
+        engine.compute_occlusion(engine.scene_root().unwrap());
 
-    //     engine.add_layer(&layer);
+        let occ_map = engine.scene().occlusion_map().unwrap();
+        let root = engine.scene_root().unwrap();
+        let occluded = occ_map.get(&root).unwrap();
 
-    //     let layer = engine.new_layer();
-    //     layer.set_position((100.0, 100.0), None);
-    //     layer.set_size(Size::points(150.0, 150.0), None);
+        // The back layer and the root should be occluded by the front layer
+        assert!(occluded.contains(&back.id), "back layer should be occluded");
+    }
 
-    //     engine.add_layer(&layer);
+    #[test]
+    pub fn occlusion_not_covered() {
+        let engine = Engine::create(1000.0, 1000.0);
 
-    //     engine.update(0.016);
+        // Two layers side by side — neither occludes the other
+        let left = engine.new_layer();
+        left.set_position((0.0, 0.0), None);
+        left.set_size(Size::points(100.0, 100.0), None);
+        left.set_background_color(Color::new_rgba(1.0, 0.0, 0.0, 1.0), None);
+        engine.add_layer(&left);
 
-    //     engine.scene().with_arena(|arena| {
-    //         let nodes = node_tree_list(engine.scene_root().unwrap(), arena, 1.0);
-    //         let nodes = node_tree_list_visible(nodes.iter(), arena);
+        let right = engine.new_layer();
+        right.set_position((200.0, 0.0), None);
+        right.set_size(Size::points(100.0, 100.0), None);
+        right.set_background_color(Color::new_rgba(0.0, 0.0, 1.0, 1.0), None);
+        engine.add_layer(&right);
 
-    //         assert_eq!(nodes.len(), 2);
-    //     });
-    // }
+        engine.update(0.016);
+        engine.clear_occlusion();
+        engine.compute_occlusion(engine.scene_root().unwrap());
+
+        let occ_map = engine.scene().occlusion_map().unwrap();
+        let root = engine.scene_root().unwrap();
+        let occluded = occ_map.get(&root).unwrap();
+
+        assert!(
+            !occluded.contains(&left.id),
+            "left layer should not be occluded"
+        );
+        assert!(
+            !occluded.contains(&right.id),
+            "right layer should not be occluded"
+        );
+    }
+
+    #[test]
+    pub fn occlusion_transparent_does_not_occlude() {
+        let engine = Engine::create(1000.0, 1000.0);
+
+        let back = engine.new_layer();
+        back.set_position((0.0, 0.0), None);
+        back.set_size(Size::points(100.0, 100.0), None);
+        back.set_background_color(Color::new_rgba(1.0, 0.0, 0.0, 1.0), None);
+        engine.add_layer(&back);
+
+        // Front layer has opacity < 1, so it cannot occlude
+        let front = engine.new_layer();
+        front.set_position((0.0, 0.0), None);
+        front.set_size(Size::points(200.0, 200.0), None);
+        front.set_background_color(Color::new_rgba(0.0, 0.0, 1.0, 1.0), None);
+        front.set_opacity(0.5, None);
+        engine.add_layer(&front);
+
+        engine.update(0.016);
+        engine.clear_occlusion();
+        engine.compute_occlusion(engine.scene_root().unwrap());
+
+        let occ_map = engine.scene().occlusion_map().unwrap();
+        let root = engine.scene_root().unwrap();
+        let occluded = occ_map.get(&root).unwrap();
+
+        assert!(
+            !occluded.contains(&back.id),
+            "back layer should not be occluded (front is semi-transparent)"
+        );
+    }
+
+    #[test]
+    pub fn occlusion_rounded_corners_do_not_occlude() {
+        let engine = Engine::create(1000.0, 1000.0);
+
+        let back = engine.new_layer();
+        back.set_position((0.0, 0.0), None);
+        back.set_size(Size::points(100.0, 100.0), None);
+        back.set_background_color(Color::new_rgba(1.0, 0.0, 0.0, 1.0), None);
+        engine.add_layer(&back);
+
+        // Front layer is opaque but has rounded corners
+        let front = engine.new_layer();
+        front.set_position((0.0, 0.0), None);
+        front.set_size(Size::points(200.0, 200.0), None);
+        front.set_background_color(Color::new_rgba(0.0, 0.0, 1.0, 1.0), None);
+        front.set_border_corner_radius(BorderRadius::new_single(10.0), None);
+        engine.add_layer(&front);
+
+        engine.update(0.016);
+        engine.clear_occlusion();
+        engine.compute_occlusion(engine.scene_root().unwrap());
+
+        let occ_map = engine.scene().occlusion_map().unwrap();
+        let root = engine.scene_root().unwrap();
+        let occluded = occ_map.get(&root).unwrap();
+
+        assert!(
+            !occluded.contains(&back.id),
+            "back layer should not be occluded (front has rounded corners)"
+        );
+    }
+
+    #[test]
+    pub fn occlusion_child_outside_clip_parent() {
+        let engine = Engine::create(1000.0, 1000.0);
+
+        // Parent with clip_children, sized 100x100 at origin
+        let parent = engine.new_layer();
+        parent.set_size(Size::points(100.0, 100.0), None);
+        parent.set_clip_children(true, None);
+        parent.set_background_color(Color::new_rgba(1.0, 1.0, 1.0, 1.0), None);
+        engine.add_layer(&parent);
+
+        // Child fully outside the parent clip (absolute positioned at 200,200)
+        let child = engine.new_layer();
+        child.set_layout_style(layers::taffy::Style {
+            position: layers::taffy::Position::Absolute,
+            ..Default::default()
+        });
+        child.set_position((200.0, 200.0), None);
+        child.set_size(Size::points(50.0, 50.0), None);
+        child.set_background_color(Color::new_rgba(1.0, 0.0, 0.0, 1.0), None);
+        parent.add_sublayer(&child);
+
+        engine.update(0.016);
+        engine.clear_occlusion();
+        engine.compute_occlusion(engine.scene_root().unwrap());
+
+        let occ_map = engine.scene().occlusion_map().unwrap();
+        let root = engine.scene_root().unwrap();
+        let occluded = occ_map.get(&root).unwrap();
+
+        assert!(
+            occluded.contains(&child.id),
+            "child outside clip parent should be occluded"
+        );
+    }
+
+    #[test]
+    pub fn occlusion_opaque_child_clipped_by_parent() {
+        let engine = Engine::create(1000.0, 1000.0);
+
+        // Behind layer: larger than the clip region (200x200 at origin)
+        let behind = engine.new_layer();
+        behind.set_position((0.0, 0.0), None);
+        behind.set_size(Size::points(200.0, 200.0), None);
+        behind.set_background_color(Color::new_rgba(1.0, 0.0, 0.0, 1.0), None);
+        engine.add_layer(&behind);
+
+        // Parent with clip_children, sized 50x50 (smaller than behind)
+        let parent = engine.new_layer();
+        parent.set_position((0.0, 0.0), None);
+        parent.set_size(Size::points(50.0, 50.0), None);
+        parent.set_clip_children(true, None);
+        engine.add_layer(&parent);
+
+        // Opaque child at 100x100 — extends beyond parent clip (50x50)
+        // Only the clipped portion (50x50) should count as occluder
+        let child = engine.new_layer();
+        child.set_position((0.0, 0.0), None);
+        child.set_size(Size::points(100.0, 100.0), None);
+        child.set_background_color(Color::new_rgba(0.0, 0.0, 1.0, 1.0), None);
+        parent.add_sublayer(&child);
+
+        engine.update(0.016);
+        engine.clear_occlusion();
+        engine.compute_occlusion(engine.scene_root().unwrap());
+
+        let occ_map = engine.scene().occlusion_map().unwrap();
+        let root = engine.scene_root().unwrap();
+        let occluded = occ_map.get(&root).unwrap();
+
+        // The behind layer (200x200) is larger than the child's clipped
+        // occluder region (50x50), so it should NOT be fully occluded
+        assert!(
+            !occluded.contains(&behind.id),
+            "layer larger than clipped occluder region should not be occluded"
+        );
+    }
+
+    #[test]
+    pub fn occlusion_background_blur_not_occluded() {
+        let engine = Engine::create(1000.0, 1000.0);
+
+        // A BackgroundBlur layer reads the backdrop, so it must never be occluded
+        let blur = engine.new_layer();
+        blur.set_position((0.0, 0.0), None);
+        blur.set_size(Size::points(100.0, 100.0), None);
+        blur.set_blend_mode(BlendMode::BackgroundBlur);
+        engine.add_layer(&blur);
+
+        // Opaque front layer
+        let front = engine.new_layer();
+        front.set_position((0.0, 0.0), None);
+        front.set_size(Size::points(200.0, 200.0), None);
+        front.set_background_color(Color::new_rgba(0.0, 0.0, 1.0, 1.0), None);
+        engine.add_layer(&front);
+
+        engine.update(0.016);
+        engine.clear_occlusion();
+        engine.compute_occlusion(engine.scene_root().unwrap());
+
+        let occ_map = engine.scene().occlusion_map().unwrap();
+        let root = engine.scene_root().unwrap();
+        let occluded = occ_map.get(&root).unwrap();
+
+        // The blur layer IS behind an opaque layer, so it will be marked occluded.
+        // This is correct: the blur layer's visual effect is invisible when fully
+        // covered. BackgroundBlur should not act as an *occluder* (it doesn't add
+        // to the opaque mask), but it can still be occluded by others.
+        assert!(
+            occluded.contains(&blur.id),
+            "blur layer should be occluded when fully behind opaque layer"
+        );
+    }
+
+    #[test]
+    pub fn occlusion_semi_transparent_parent_subtree_does_not_occlude() {
+        let engine = Engine::create(1000.0, 1000.0);
+
+        // Back layer — should NOT be occluded because the front subtree is semi-transparent
+        let back = engine.new_layer();
+        back.set_position((0.0, 0.0), None);
+        back.set_size(Size::points(100.0, 100.0), None);
+        back.set_background_color(Color::new_rgba(1.0, 0.0, 0.0, 1.0), None);
+        engine.add_layer(&back);
+
+        // Semi-transparent parent (opacity 0.9) — entire subtree cannot occlude
+        let parent = engine.new_layer();
+        parent.set_position((0.0, 0.0), None);
+        parent.set_size(Size::points(200.0, 200.0), None);
+        parent.set_opacity(0.9, None);
+        engine.add_layer(&parent);
+
+        // Child with opaque background — but parent opacity < 1.0,
+        // so this child must NOT act as an occluder
+        let child = engine.new_layer();
+        child.set_position((0.0, 0.0), None);
+        child.set_size(Size::points(200.0, 200.0), None);
+        child.set_background_color(Color::new_rgba(0.0, 0.0, 1.0, 1.0), None);
+        parent.add_sublayer(&child);
+
+        engine.update(0.016);
+        engine.clear_occlusion();
+        engine.compute_occlusion(engine.scene_root().unwrap());
+
+        let occ_map = engine.scene().occlusion_map().unwrap();
+        let root = engine.scene_root().unwrap();
+        let occluded = occ_map.get(&root).unwrap();
+
+        assert!(
+            !occluded.contains(&back.id),
+            "back layer should not be occluded by child of semi-transparent parent"
+        );
+    }
+
+    #[test]
+    pub fn occlusion_hidden_parent_subtree_does_not_occlude() {
+        let engine = Engine::create(1000.0, 1000.0);
+
+        // Back layer — should NOT be occluded because the front subtree is hidden
+        let back = engine.new_layer();
+        back.set_position((0.0, 0.0), None);
+        back.set_size(Size::points(100.0, 100.0), None);
+        back.set_background_color(Color::new_rgba(1.0, 0.0, 0.0, 1.0), None);
+        engine.add_layer(&back);
+
+        // Hidden parent — entire subtree should be ignored
+        let parent = engine.new_layer();
+        parent.set_position((0.0, 0.0), None);
+        parent.set_size(Size::points(200.0, 200.0), None);
+        parent.set_hidden(true);
+        engine.add_layer(&parent);
+
+        // Opaque child inside hidden parent — must not occlude anything
+        let child = engine.new_layer();
+        child.set_position((0.0, 0.0), None);
+        child.set_size(Size::points(200.0, 200.0), None);
+        child.set_background_color(Color::new_rgba(0.0, 0.0, 1.0, 1.0), None);
+        parent.add_sublayer(&child);
+
+        engine.update(0.016);
+        engine.clear_occlusion();
+        engine.compute_occlusion(engine.scene_root().unwrap());
+
+        let occ_map = engine.scene().occlusion_map().unwrap();
+        let root = engine.scene_root().unwrap();
+        let occluded = occ_map.get(&root).unwrap();
+
+        assert!(
+            !occluded.contains(&back.id),
+            "back layer should not be occluded by child of hidden parent"
+        );
+    }
+
+    /// A layer with transparent background but `content_opaque = true` should
+    /// still act as an occluder, hiding the layer behind it.
+    #[test]
+    pub fn occlusion_content_opaque_occludes() {
+        let engine = Engine::create(1000.0, 1000.0);
+
+        // Back layer — should be occluded
+        let back = engine.new_layer();
+        back.set_position((0.0, 0.0), None);
+        back.set_size(Size::points(200.0, 200.0), None);
+        back.set_background_color(Color::new_rgba(1.0, 0.0, 0.0, 1.0), None);
+        engine.add_layer(&back);
+
+        // Front layer — transparent background but content declared opaque
+        let front = engine.new_layer();
+        front.set_position((0.0, 0.0), None);
+        front.set_size(Size::points(200.0, 200.0), None);
+        // background is transparent (default)
+        front.set_content_opaque(true);
+        engine.add_layer(&front);
+
+        engine.update(0.016);
+        engine.clear_occlusion();
+        engine.compute_occlusion(engine.scene_root().unwrap());
+
+        let occ_map = engine.scene().occlusion_map().unwrap();
+        let root = engine.scene_root().unwrap();
+        let occluded = occ_map.get(&root).unwrap();
+
+        assert!(
+            occluded.contains(&back.id),
+            "back layer should be occluded by content_opaque front layer"
+        );
+    }
+
+    /// A layer with `content_opaque = false` (default) and transparent
+    /// background should NOT occlude.
+    #[test]
+    pub fn occlusion_content_not_opaque_does_not_occlude() {
+        let engine = Engine::create(1000.0, 1000.0);
+
+        let back = engine.new_layer();
+        back.set_position((0.0, 0.0), None);
+        back.set_size(Size::points(200.0, 200.0), None);
+        back.set_background_color(Color::new_rgba(1.0, 0.0, 0.0, 1.0), None);
+        engine.add_layer(&back);
+
+        let front = engine.new_layer();
+        front.set_position((0.0, 0.0), None);
+        front.set_size(Size::points(200.0, 200.0), None);
+        // transparent background and content_opaque not set (default false)
+        engine.add_layer(&front);
+
+        engine.update(0.016);
+        engine.clear_occlusion();
+        engine.compute_occlusion(engine.scene_root().unwrap());
+
+        let occ_map = engine.scene().occlusion_map().unwrap();
+        let root = engine.scene_root().unwrap();
+        let occluded = occ_map.get(&root).unwrap();
+
+        assert!(
+            !occluded.contains(&back.id),
+            "back layer should NOT be occluded when front is not opaque"
+        );
+    }
 }

--- a/tests/transaction_handler.rs
+++ b/tests/transaction_handler.rs
@@ -25,7 +25,7 @@ fn noop_waker() -> Waker {
 pub fn call_finish_transaction() {
     let engine = Engine::create(1000.0, 1000.0);
     let layer = engine.new_layer();
-    engine.add_layer(&layer);
+    engine.add_layer(&layer).unwrap();
 
     let transaction = layer.set_position(
         Point { x: 200.0, y: 100.0 },
@@ -60,7 +60,7 @@ pub fn call_finish_transaction() {
 pub fn call_start_transaction() {
     let engine = Engine::create(1000.0, 1000.0);
     let layer = engine.new_layer();
-    engine.add_layer(&layer);
+    engine.add_layer(&layer).unwrap();
 
     let transaction = layer.set_position(
         Point { x: 200.0, y: 100.0 },
@@ -104,7 +104,7 @@ pub fn call_start_transaction() {
 pub fn call_update_transaction() {
     let engine = Engine::create(1000.0, 1000.0);
     let layer = engine.new_layer();
-    engine.add_layer(&layer);
+    engine.add_layer(&layer).unwrap();
 
     let called = Arc::new(RwLock::new(0.0));
     let c = called.clone();
@@ -135,7 +135,7 @@ pub fn call_update_transaction() {
 pub fn call_finish_transaction_spring() {
     let engine = Engine::create(1000.0, 1000.0);
     let layer = engine.new_layer();
-    engine.add_layer(&layer);
+    engine.add_layer(&layer).unwrap();
 
     // let s = Spring::with_duration_and_bounce(1.0, 0.2);
     // println!("spring {:#?}", s);
@@ -186,7 +186,7 @@ pub fn call_finish_transaction_spring() {
 pub fn call_finish_transaction_spring_predictable() {
     let engine = Engine::create(1000.0, 1000.0);
     let layer = engine.new_layer();
-    engine.add_layer(&layer);
+    engine.add_layer(&layer).unwrap();
 
     let transaction = layer.set_position(
         Point { x: 200.0, y: 100.0 },
@@ -223,7 +223,7 @@ pub fn call_finish_transaction_spring_predictable() {
 pub fn call_start_value() {
     let engine = Engine::create(1000.0, 1000.0);
     let layer = engine.new_layer();
-    engine.add_layer(&layer);
+    engine.add_layer(&layer).unwrap();
 
     layer.set_position(
         Point { x: 200.0, y: 100.0 },
@@ -283,7 +283,7 @@ pub fn call_start_value() {
 pub fn call_update_value() {
     let engine = Engine::create(1000.0, 1000.0);
     let layer = engine.new_layer();
-    engine.add_layer(&layer);
+    engine.add_layer(&layer).unwrap();
 
     layer.set_position(
         Point { x: 200.0, y: 100.0 },
@@ -347,7 +347,7 @@ pub fn call_update_value() {
 pub fn transition_future_resolves_when_transaction_already_done() {
     let engine = Engine::create(1000.0, 1000.0);
     let layer = engine.new_layer();
-    engine.add_layer(&layer);
+    engine.add_layer(&layer).unwrap();
 
     let transaction =
         layer.set_position(Point { x: 200.0, y: 100.0 }, Some(Transition::linear(0.1)));
@@ -375,7 +375,7 @@ pub fn transition_future_resolves_when_transaction_already_done() {
 pub fn transition_future_resolves_when_transaction_completes_before_poll() {
     let engine = Engine::create(1000.0, 1000.0);
     let layer = engine.new_layer();
-    engine.add_layer(&layer);
+    engine.add_layer(&layer).unwrap();
 
     let transaction =
         layer.set_position(Point { x: 200.0, y: 100.0 }, Some(Transition::linear(0.1)));

--- a/tests/view_builder.rs
+++ b/tests/view_builder.rs
@@ -84,7 +84,7 @@ pub fn simple_build() {
     let engine = Engine::create(1000.0, 1000.0);
     let layer = engine.new_layer();
 
-    engine.add_layer(&layer);
+    engine.add_layer(&layer).unwrap();
 
     let lt = LayerTreeBuilder::default()
         .children(vec![LayerTreeBuilder::default().build().unwrap()])
@@ -100,7 +100,7 @@ pub fn build_a_view() {
     let engine = Engine::create(1000.0, 1000.0);
     let layer = engine.new_layer();
 
-    engine.add_layer(&layer);
+    engine.add_layer(&layer).unwrap();
 
     let initial = false;
     let view = View::new("test_view", initial, render_one_child_view);
@@ -117,7 +117,7 @@ pub fn rebuild_a_view() {
     let engine = Engine::create(1000.0, 1000.0);
     let layer = engine.new_layer();
 
-    engine.add_layer(&layer);
+    engine.add_layer(&layer).unwrap();
 
     let initial = false;
     let view = View::new("test_view", initial, render_one_child_view);
@@ -153,7 +153,7 @@ pub fn nested_views() {
     let engine = Engine::create(1000.0, 1000.0);
     let layer = engine.new_layer();
 
-    engine.add_layer(&layer);
+    engine.add_layer(&layer).unwrap();
 
     let initial = false;
     let view = View::new("parent_view", initial, render_main_view);
@@ -189,7 +189,7 @@ pub fn nested_views() {
 fn layer_tree_builder_children_recover_from_zero_opacity_parent() {
     let engine = Engine::create(1000.0, 1000.0);
     let layer = engine.new_layer();
-    engine.add_layer(&layer);
+    engine.add_layer(&layer).unwrap();
 
     let child_tree = LayerTreeBuilder::default()
         .key("child")
@@ -249,7 +249,7 @@ fn layer_tree_replicate_node() {
     // Create a root layer first so source_layer and replica_holder are siblings
     let root = engine.new_layer();
     root.set_size(Size::points(1000.0, 1000.0), None);
-    engine.add_layer(&root);
+    engine.add_layer(&root).unwrap();
 
     // Create a source layer to replicate
     let source_layer = engine.new_layer();
@@ -260,12 +260,12 @@ fn layer_tree_replicate_node() {
         },
         None,
     );
-    root.add_sublayer(&source_layer);
+    root.add_sublayer(&source_layer).unwrap();
 
     // Create a layer to hold the replicated content
     let replica_holder = engine.new_layer();
     replica_holder.set_size(Size::points(200.0, 200.0), None);
-    root.add_sublayer(&replica_holder);
+    root.add_sublayer(&replica_holder).unwrap();
 
     // Build a layer tree that replicates the source layer
     // This sets the content_draw_func on replica_holder to render source_layer
@@ -301,14 +301,14 @@ fn layer_tree_replicate_node_descendant_follower() {
         },
         None,
     );
-    engine.add_layer(&source_layer);
+    engine.add_layer(&source_layer).unwrap();
 
     // Create a replica layer as a CHILD of source_layer
     // This creates the circular dependency: rendering source_layer renders replica,
     // and replica's content_draw_func tries to render source_layer again
     let replica = engine.new_layer();
     replica.set_size(Size::points(50.0, 50.0), None);
-    source_layer.add_sublayer(&replica);
+    source_layer.add_sublayer(&replica).unwrap();
 
     // Set up the replica to mirror the source
     let replicate_tree = LayerTreeBuilder::default()


### PR DESCRIPTION
## Summary

This PR adds three improvements to the rendering engine: graceful error propagation for stale layer handles, occlusion culling for opaque nodes, and damage-based subtree culling.

### Error propagation
- Replace panics from freed indextree nodes with `Result<(), LayerError>` returns
- Callers can now log, skip, or recover from stale handles instead of crashing

### Occlusion culling
- New `compute_occlusion()` traversal identifies nodes fully covered by opaque siblings
- `set_content_opaque()` marks layers whose content fills their bounds (e.g. desktop background)
- `render_node_tree` skips painting occluded nodes while still traversing children (a child may be the occluder)

### Damage-based subtree culling
- `render_node_tree` and `paint_node_tree` accept an optional `damage_region: Option<&skia::Region>`
- Before recursing into a child, checks `global_transformed_bounds_with_children` against the damage region
- Entire subtrees outside the damaged area are skipped, avoiding unnecessary paint calls
