### PR TITLE
feat: keyframe animation timing

### DIFF
--- a/src/engine/animation/mod.rs
+++ b/src/engine/animation/mod.rs
@@ -62,19 +62,16 @@ mod easing;
 mod spring;
 mod timing;
 
-pub use self::timing::TimingFunction;
+pub use self::timing::{KeyframeSegment, TimingFunction};
 
 pub use easing::Easing;
 pub use spring::Spring;
 
 /// Transition is a data structure that contains the information needed to
 /// create an animation that can start at a later time.
-#[repr(C)]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub struct Transition {
-    // pub duration: f32,
     pub delay: f32,
-    // easing
     pub timing: TimingFunction,
 }
 /// Default Transition, 0.3 seconds, no delay, ease out
@@ -140,6 +137,12 @@ impl Transition {
         Transition {
             delay: 0.0,
             timing: TimingFunction::spring_with_initial_velocity(duration, bounce, velocity),
+        }
+    }
+    pub fn keyframes(segments: Vec<KeyframeSegment>) -> Self {
+        Transition {
+            delay: 0.0,
+            timing: TimingFunction::keyframes(segments),
         }
     }
 }

--- a/src/engine/animation/timing.rs
+++ b/src/engine/animation/timing.rs
@@ -1,10 +1,30 @@
 use super::{spring::Spring, Easing};
 
+/// A single segment within a keyframe animation.
+///
+/// Each segment spans a `duration` in seconds and maps a range of
+/// overall animation progress (`start_progress`..`end_progress`)
+/// through its own `easing` curve.
 #[derive(Clone, Copy, Debug)]
+pub struct KeyframeSegment {
+    /// How long this segment lasts, in seconds.
+    pub duration: f32,
+    /// The bezier easing curve applied within this segment.
+    pub easing: Easing,
+    /// The animation progress value at the start of this segment (0.0–1.0).
+    pub start_progress: f32,
+    /// The animation progress value at the end of this segment (0.0–1.0).
+    pub end_progress: f32,
+}
+
+#[derive(Clone, Debug)]
 /// Possible timing functions for an animation.
 pub enum TimingFunction {
     Easing(Easing, f32),
     Spring(Spring),
+    /// Piecewise timing: a sequence of segments, each with its own
+    /// duration, easing, and progress range.
+    Keyframes(Vec<KeyframeSegment>),
 }
 
 impl TimingFunction {
@@ -59,6 +79,11 @@ impl TimingFunction {
         ))
     }
 
+    /// Build a keyframes timing function from a list of segments.
+    pub fn keyframes(segments: Vec<KeyframeSegment>) -> Self {
+        TimingFunction::Keyframes(segments)
+    }
+
     pub fn update_at(&mut self, elapsed: f32) -> (f32, f32) {
         match self {
             TimingFunction::Easing(Easing { x1, x2, y1, y2 }, duration) => {
@@ -68,12 +93,55 @@ impl TimingFunction {
                 (ease(t), t)
             }
             TimingFunction::Spring(solver) => (solver.update_at(elapsed), elapsed),
+            TimingFunction::Keyframes(segments) => {
+                let total_duration: f32 = segments.iter().map(|s| s.duration).sum();
+                if total_duration <= 0.0 || segments.is_empty() {
+                    return (1.0, 1.0);
+                }
+                let t = elapsed / total_duration;
+                let t_clamped = t.clamp(0.0, 1.0);
+
+                // Find which segment the elapsed time falls into
+                let mut accumulated = 0.0_f32;
+                for seg in segments.iter() {
+                    let seg_end = accumulated + seg.duration;
+                    if elapsed < seg_end || (elapsed >= seg_end && seg_end >= total_duration) {
+                        // We're in this segment
+                        let seg_elapsed = elapsed - accumulated;
+                        let seg_t = if seg.duration > 0.0 {
+                            (seg_elapsed / seg.duration).clamp(0.0, 1.0)
+                        } else {
+                            1.0
+                        };
+                        // Apply the segment's easing curve
+                        let eased = bezier_easing::bezier_easing(
+                            seg.easing.x1,
+                            seg.easing.y1,
+                            seg.easing.x2,
+                            seg.easing.y2,
+                        )
+                        .unwrap()(seg_t);
+                        // Map eased value to the segment's progress range
+                        let progress = seg.start_progress
+                            + (seg.end_progress - seg.start_progress) * eased;
+                        return (progress, t_clamped);
+                    }
+                    accumulated = seg_end;
+                }
+                // Past all segments — return final progress
+                let last = segments.last().unwrap();
+                (last.end_progress, t_clamped)
+            }
         }
     }
     pub fn done(&self, start: f32, current: f32) -> bool {
         match self {
             TimingFunction::Easing(_, duration) => current - start >= *duration,
             TimingFunction::Spring(solver) => solver.done(current - start),
+            TimingFunction::Keyframes(segments) => {
+                let total_duration: f32 = segments.iter().map(|s| s.duration).sum();
+                current - start >= total_duration
+            }
         }
     }
 }

--- a/src/engine/animation/timing.rs
+++ b/src/engine/animation/timing.rs
@@ -24,7 +24,8 @@ pub enum TimingFunction {
     Spring(Spring),
     /// Piecewise timing: a sequence of segments, each with its own
     /// duration, easing, and progress range.
-    Keyframes(Vec<KeyframeSegment>),
+    /// The second field caches the total duration to avoid recomputing per frame.
+    Keyframes(Vec<KeyframeSegment>, f32),
 }
 
 impl TimingFunction {
@@ -81,7 +82,8 @@ impl TimingFunction {
 
     /// Build a keyframes timing function from a list of segments.
     pub fn keyframes(segments: Vec<KeyframeSegment>) -> Self {
-        TimingFunction::Keyframes(segments)
+        let total_duration: f32 = segments.iter().map(|s| s.duration).sum();
+        TimingFunction::Keyframes(segments, total_duration)
     }
 
     pub fn update_at(&mut self, elapsed: f32) -> (f32, f32) {
@@ -93,8 +95,8 @@ impl TimingFunction {
                 (ease(t), t)
             }
             TimingFunction::Spring(solver) => (solver.update_at(elapsed), elapsed),
-            TimingFunction::Keyframes(segments) => {
-                let total_duration: f32 = segments.iter().map(|s| s.duration).sum();
+            TimingFunction::Keyframes(segments, total_duration) => {
+                let total_duration = *total_duration;
                 if total_duration <= 0.0 || segments.is_empty() {
                     return (1.0, 1.0);
                 }
@@ -138,10 +140,7 @@ impl TimingFunction {
         match self {
             TimingFunction::Easing(_, duration) => current - start >= *duration,
             TimingFunction::Spring(solver) => solver.done(current - start),
-            TimingFunction::Keyframes(segments) => {
-                let total_duration: f32 = segments.iter().map(|s| s.duration).sum();
-                current - start >= total_duration
-            }
+            TimingFunction::Keyframes(_, total_duration) => current - start >= *total_duration,
         }
     }
 }

--- a/src/engine/animation/timing.rs
+++ b/src/engine/animation/timing.rs
@@ -122,8 +122,8 @@ impl TimingFunction {
                         )
                         .unwrap()(seg_t);
                         // Map eased value to the segment's progress range
-                        let progress = seg.start_progress
-                            + (seg.end_progress - seg.start_progress) * eased;
+                        let progress =
+                            seg.start_progress + (seg.end_progress - seg.start_progress) * eased;
                         return (progress, t_clamped);
                     }
                     accumulated = seg_end;

--- a/src/engine/command.rs
+++ b/src/engine/command.rs
@@ -158,10 +158,9 @@ macro_rules! change_model {
 
                 let value_id = self.model.$variable_name.id;
                 let change = Arc::new(ModelChange {
-                    value_change: self.model.$variable_name.to(value.clone(), transition),
+                    value_change: self.model.$variable_name.to(value.clone(), transition.clone()),
                     flag: flags,
                 });
-                // }
 
                 let animation = transition.map(|t| {
                     // if there is a transition

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1051,7 +1051,7 @@ impl Engine {
             Animation {
                 start,
                 // duration: transition.duration,
-                timing: transition.timing,
+                timing: transition.timing.clone(),
             },
             autostart,
         )

--- a/src/engine/stages/mod.rs
+++ b/src/engine/stages/mod.rs
@@ -639,7 +639,7 @@ pub fn send_debugger(engine: &super::Engine) {
                             format!("easing ({:.2}s)", duration)
                         }
                         crate::engine::animation::TimingFunction::Spring(_) => "spring".to_string(),
-                        crate::engine::animation::TimingFunction::Keyframes(segments) => {
+                        crate::engine::animation::TimingFunction::Keyframes(segments, _) => {
                             let total: f32 = segments.iter().map(|s| s.duration).sum();
                             format!("keyframes ({}seg, {:.2}s)", segments.len(), total)
                         }

--- a/src/engine/stages/mod.rs
+++ b/src/engine/stages/mod.rs
@@ -639,6 +639,10 @@ pub fn send_debugger(engine: &super::Engine) {
                             format!("easing ({:.2}s)", duration)
                         }
                         crate::engine::animation::TimingFunction::Spring(_) => "spring".to_string(),
+                        crate::engine::animation::TimingFunction::Keyframes(segments) => {
+                            let total: f32 = segments.iter().map(|s| s.duration).sum();
+                            format!("keyframes ({}seg, {:.2}s)", segments.len(), total)
+                        }
                     };
                     let node_id: usize = change.node_id.0.into();
                     Some(DebugAnimationInfo {

--- a/src/layers/layer/mod.rs
+++ b/src/layers/layer/mod.rs
@@ -289,7 +289,7 @@ impl Layer {
         let value_id = self.model.size.id;
 
         let change: Arc<ModelChange<Size>> = Arc::new(ModelChange {
-            value_change: self.model.size.to(value, transition),
+            value_change: self.model.size.to(value, transition.clone()),
             flag: flags,
         });
 

--- a/src/view/build_layer_tree.rs
+++ b/src/view/build_layer_tree.rs
@@ -72,47 +72,47 @@ impl BuildLayerTree for Layer {
             scene_layer.set_key(viewlayer_tree.key.clone());
         }
 
-        if let Some((position, transition)) = viewlayer_tree.position {
-            scene_layer.set_position(position, transition);
+        if let Some((position, ref transition)) = viewlayer_tree.position {
+            scene_layer.set_position(position, transition.clone());
         }
-        if let Some((anchor_point, transition)) = viewlayer_tree.anchor_point {
-            scene_layer.set_anchor_point(anchor_point, transition);
+        if let Some((anchor_point, ref transition)) = viewlayer_tree.anchor_point {
+            scene_layer.set_anchor_point(anchor_point, transition.clone());
         }
-        if let Some((scale, transition)) = viewlayer_tree.scale {
-            scene_layer.set_scale(scale, transition);
+        if let Some((scale, ref transition)) = viewlayer_tree.scale {
+            scene_layer.set_scale(scale, transition.clone());
         }
-        if let Some((background_color, transition)) = viewlayer_tree.background_color.clone() {
-            scene_layer.set_background_color(background_color, transition);
+        if let Some((ref background_color, ref transition)) = viewlayer_tree.background_color {
+            scene_layer.set_background_color(background_color.clone(), transition.clone());
         }
-        if let Some((border_color, transition)) = viewlayer_tree.border_color {
-            scene_layer.set_border_color(border_color, transition);
+        if let Some((border_color, ref transition)) = viewlayer_tree.border_color {
+            scene_layer.set_border_color(border_color, transition.clone());
         }
-        if let Some((border_width, transition)) = viewlayer_tree.border_width {
-            scene_layer.set_border_width(border_width, transition);
+        if let Some((border_width, ref transition)) = viewlayer_tree.border_width {
+            scene_layer.set_border_width(border_width, transition.clone());
         }
-        if let Some((border_corner_radius, transition)) = viewlayer_tree.border_corner_radius {
-            scene_layer.set_border_corner_radius(border_corner_radius, transition);
+        if let Some((border_corner_radius, ref transition)) = viewlayer_tree.border_corner_radius {
+            scene_layer.set_border_corner_radius(border_corner_radius, transition.clone());
         }
-        if let Some((size, transition)) = viewlayer_tree.size {
-            scene_layer.set_size(size, transition);
+        if let Some((size, ref transition)) = viewlayer_tree.size {
+            scene_layer.set_size(size, transition.clone());
         }
-        if let Some((shadow_offset, transition)) = viewlayer_tree.shadow_offset {
-            scene_layer.set_shadow_offset(shadow_offset, transition);
+        if let Some((shadow_offset, ref transition)) = viewlayer_tree.shadow_offset {
+            scene_layer.set_shadow_offset(shadow_offset, transition.clone());
         }
-        if let Some((shadow_radius, transition)) = viewlayer_tree.shadow_radius {
-            scene_layer.set_shadow_radius(shadow_radius, transition);
+        if let Some((shadow_radius, ref transition)) = viewlayer_tree.shadow_radius {
+            scene_layer.set_shadow_radius(shadow_radius, transition.clone());
         }
-        if let Some((shadow_color, transition)) = viewlayer_tree.shadow_color {
-            scene_layer.set_shadow_color(shadow_color, transition);
+        if let Some((shadow_color, ref transition)) = viewlayer_tree.shadow_color {
+            scene_layer.set_shadow_color(shadow_color, transition.clone());
         }
-        if let Some((shadow_spread, transition)) = viewlayer_tree.shadow_spread {
-            scene_layer.set_shadow_spread(shadow_spread, transition);
+        if let Some((shadow_spread, ref transition)) = viewlayer_tree.shadow_spread {
+            scene_layer.set_shadow_spread(shadow_spread, transition.clone());
         }
-        if let Some(layout_style) = viewlayer_tree.layout_style.clone() {
-            scene_layer.set_layout_style(layout_style);
+        if let Some(ref layout_style) = viewlayer_tree.layout_style {
+            scene_layer.set_layout_style(layout_style.clone());
         }
-        if let Some((opacity, transition)) = viewlayer_tree.opacity {
-            scene_layer.set_opacity(opacity, transition);
+        if let Some((opacity, ref transition)) = viewlayer_tree.opacity {
+            scene_layer.set_opacity(opacity, transition.clone());
         }
         if let Some(blend_mode) = viewlayer_tree.blend_mode {
             scene_layer.set_blend_mode(blend_mode);

--- a/tests/keyframe_animations.rs
+++ b/tests/keyframe_animations.rs
@@ -1,0 +1,244 @@
+use layers::prelude::*;
+
+/// Helper to create a simple two-segment keyframe timing:
+/// first half holds at 0, second half eases linearly to 1.
+fn hold_then_linear() -> Vec<KeyframeSegment> {
+    vec![
+        KeyframeSegment {
+            duration: 0.5,
+            easing: Easing::linear(),
+            start_progress: 0.0,
+            end_progress: 0.0, // hold
+        },
+        KeyframeSegment {
+            duration: 0.5,
+            easing: Easing::linear(),
+            start_progress: 0.0,
+            end_progress: 1.0, // animate
+        },
+    ]
+}
+
+#[test]
+fn keyframe_timing_update_at_hold_segment() {
+    let mut tf = TimingFunction::keyframes(hold_then_linear());
+
+    // During the hold segment (0–0.5s), progress should stay at 0.0
+    let (progress, _) = tf.update_at(0.0);
+    assert!((progress - 0.0).abs() < 0.001, "progress at t=0 should be 0.0, got {progress}");
+
+    let (progress, _) = tf.update_at(0.25);
+    assert!((progress - 0.0).abs() < 0.001, "progress at t=0.25 should be 0.0 (hold), got {progress}");
+
+    let (progress, _) = tf.update_at(0.49);
+    assert!((progress - 0.0).abs() < 0.001, "progress at t=0.49 should be ~0.0 (hold), got {progress}");
+}
+
+#[test]
+fn keyframe_timing_update_at_animate_segment() {
+    let mut tf = TimingFunction::keyframes(hold_then_linear());
+
+    // During the animate segment (0.5–1.0s), progress should go 0.0→1.0
+    let (progress, _) = tf.update_at(0.5);
+    assert!((progress - 0.0).abs() < 0.01, "progress at t=0.5 should be ~0.0, got {progress}");
+
+    let (progress, _) = tf.update_at(0.75);
+    assert!((progress - 0.5).abs() < 0.01, "progress at t=0.75 should be ~0.5, got {progress}");
+
+    let (progress, _) = tf.update_at(1.0);
+    assert!((progress - 1.0).abs() < 0.01, "progress at t=1.0 should be ~1.0, got {progress}");
+}
+
+#[test]
+fn keyframe_timing_done() {
+    let tf = TimingFunction::keyframes(hold_then_linear());
+
+    // Total duration is 1.0s
+    assert!(!tf.done(0.0, 0.5), "should not be done at 0.5s");
+    assert!(!tf.done(0.0, 0.99), "should not be done at 0.99s");
+    assert!(tf.done(0.0, 1.0), "should be done at 1.0s");
+    assert!(tf.done(0.0, 1.5), "should be done past total duration");
+}
+
+#[test]
+fn keyframe_timing_done_with_start_offset() {
+    let tf = TimingFunction::keyframes(hold_then_linear());
+
+    // Animation starts at t=2.0, total duration is 1.0s
+    assert!(!tf.done(2.0, 2.5), "should not be done 0.5s in");
+    assert!(tf.done(2.0, 3.0), "should be done at start + total_duration");
+}
+
+#[test]
+fn keyframe_three_segments() {
+    // Three segments: ease-in to 30%, hold at 30%, ease-out to 100%
+    let mut tf = TimingFunction::keyframes(vec![
+        KeyframeSegment {
+            duration: 0.3,
+            easing: Easing::linear(),
+            start_progress: 0.0,
+            end_progress: 0.3,
+        },
+        KeyframeSegment {
+            duration: 0.2,
+            easing: Easing::linear(),
+            start_progress: 0.3,
+            end_progress: 0.3, // hold
+        },
+        KeyframeSegment {
+            duration: 0.5,
+            easing: Easing::linear(),
+            start_progress: 0.3,
+            end_progress: 1.0,
+        },
+    ]);
+
+    // End of first segment
+    let (progress, _) = tf.update_at(0.3);
+    assert!((progress - 0.3).abs() < 0.01, "end of seg 0: expected ~0.3, got {progress}");
+
+    // Middle of hold segment
+    let (progress, _) = tf.update_at(0.4);
+    assert!((progress - 0.3).abs() < 0.01, "mid hold: expected ~0.3, got {progress}");
+
+    // End of hold segment
+    let (progress, _) = tf.update_at(0.5);
+    assert!((progress - 0.3).abs() < 0.01, "end of hold: expected ~0.3, got {progress}");
+
+    // Middle of final segment (0.75s = 0.5 into a 0.5s segment = 50%)
+    let (progress, _) = tf.update_at(0.75);
+    let expected = 0.3 + (1.0 - 0.3) * 0.5; // 0.65
+    assert!((progress - expected).abs() < 0.01, "mid final: expected ~{expected}, got {progress}");
+
+    // End
+    let (progress, _) = tf.update_at(1.0);
+    assert!((progress - 1.0).abs() < 0.01, "end: expected ~1.0, got {progress}");
+}
+
+#[test]
+fn keyframe_normalized_time_output() {
+    let mut tf = TimingFunction::keyframes(hold_then_linear());
+
+    // The second return value should be normalized time (0.0–1.0)
+    let (_, t) = tf.update_at(0.0);
+    assert!((t - 0.0).abs() < 0.001);
+
+    let (_, t) = tf.update_at(0.5);
+    assert!((t - 0.5).abs() < 0.001);
+
+    let (_, t) = tf.update_at(1.0);
+    assert!((t - 1.0).abs() < 0.001);
+}
+
+#[test]
+fn keyframe_empty_segments() {
+    let mut tf = TimingFunction::keyframes(vec![]);
+
+    // Empty keyframes should immediately resolve
+    let (progress, _) = tf.update_at(0.0);
+    assert!((progress - 1.0).abs() < 0.001, "empty keyframes should return 1.0");
+
+    let tf = TimingFunction::keyframes(vec![]);
+    assert!(tf.done(0.0, 0.0), "empty keyframes should be immediately done");
+}
+
+#[test]
+fn keyframe_single_segment() {
+    let mut tf = TimingFunction::keyframes(vec![KeyframeSegment {
+        duration: 1.0,
+        easing: Easing::linear(),
+        start_progress: 0.0,
+        end_progress: 1.0,
+    }]);
+
+    // Should behave like a simple linear animation
+    let (progress, _) = tf.update_at(0.0);
+    assert!((progress - 0.0).abs() < 0.001);
+
+    let (progress, _) = tf.update_at(0.5);
+    assert!((progress - 0.5).abs() < 0.001);
+
+    let (progress, _) = tf.update_at(1.0);
+    assert!((progress - 1.0).abs() < 0.001);
+}
+
+#[test]
+fn keyframe_with_easing_curves() {
+    // Use ease_in for first segment — progress should lag behind linear
+    let mut tf = TimingFunction::keyframes(vec![
+        KeyframeSegment {
+            duration: 1.0,
+            easing: Easing::ease_in(),
+            start_progress: 0.0,
+            end_progress: 1.0,
+        },
+    ]);
+
+    let (progress, _) = tf.update_at(0.5);
+    // ease_in at t=0.5 should be less than 0.5 (starts slow)
+    assert!(progress < 0.5, "ease_in at t=0.5 should be < 0.5, got {progress}");
+    assert!(progress > 0.0, "ease_in at t=0.5 should be > 0.0, got {progress}");
+}
+
+#[test]
+fn keyframe_layer_integration() {
+    // Test that keyframes work end-to-end with the engine
+    let engine = Engine::create(1000.0, 1000.0);
+    let layer = engine.new_layer();
+    engine.add_layer(&layer).unwrap();
+
+    let initial_pos = layer.position();
+
+    // Hold for 0.5s, then animate to (100, 100) over 0.5s
+    layer.set_position(
+        (100.0, 100.0),
+        Transition::keyframes(hold_then_linear()),
+    );
+
+    // Advance 0.4s — still in hold segment, position should not change
+    engine.update(0.2);
+    engine.update(0.2);
+    assert_eq!(
+        layer.position(),
+        initial_pos,
+        "position should not change during hold segment"
+    );
+
+    // Advance to 0.75s — halfway through animate segment
+    engine.update(0.2);
+    engine.update(0.15);
+    let pos = layer.position();
+    assert!(
+        pos.x > 0.0 && pos.x < 100.0,
+        "position should be mid-animation at t=0.75, got {:?}",
+        pos
+    );
+
+    // Advance past end
+    engine.update(0.5);
+    engine.update(0.5);
+    let pos = layer.position();
+    assert!(
+        (pos.x - 100.0).abs() < 1.0 && (pos.y - 100.0).abs() < 1.0,
+        "position should be at target after animation, got {:?}",
+        pos
+    );
+}
+
+#[test]
+fn keyframe_transition_constructor() {
+    let t = Transition::keyframes(vec![KeyframeSegment {
+        duration: 0.5,
+        easing: Easing::ease_out(),
+        start_progress: 0.0,
+        end_progress: 1.0,
+    }]);
+    assert_eq!(t.delay, 0.0);
+    match t.timing {
+        TimingFunction::Keyframes(ref segments) => {
+            assert_eq!(segments.len(), 1);
+            assert_eq!(segments[0].duration, 0.5);
+        }
+        _ => panic!("expected Keyframes timing"),
+    }
+}

--- a/tests/keyframe_animations.rs
+++ b/tests/keyframe_animations.rs
@@ -25,13 +25,22 @@ fn keyframe_timing_update_at_hold_segment() {
 
     // During the hold segment (0–0.5s), progress should stay at 0.0
     let (progress, _) = tf.update_at(0.0);
-    assert!((progress - 0.0).abs() < 0.001, "progress at t=0 should be 0.0, got {progress}");
+    assert!(
+        (progress - 0.0).abs() < 0.001,
+        "progress at t=0 should be 0.0, got {progress}"
+    );
 
     let (progress, _) = tf.update_at(0.25);
-    assert!((progress - 0.0).abs() < 0.001, "progress at t=0.25 should be 0.0 (hold), got {progress}");
+    assert!(
+        (progress - 0.0).abs() < 0.001,
+        "progress at t=0.25 should be 0.0 (hold), got {progress}"
+    );
 
     let (progress, _) = tf.update_at(0.49);
-    assert!((progress - 0.0).abs() < 0.001, "progress at t=0.49 should be ~0.0 (hold), got {progress}");
+    assert!(
+        (progress - 0.0).abs() < 0.001,
+        "progress at t=0.49 should be ~0.0 (hold), got {progress}"
+    );
 }
 
 #[test]
@@ -40,13 +49,22 @@ fn keyframe_timing_update_at_animate_segment() {
 
     // During the animate segment (0.5–1.0s), progress should go 0.0→1.0
     let (progress, _) = tf.update_at(0.5);
-    assert!((progress - 0.0).abs() < 0.01, "progress at t=0.5 should be ~0.0, got {progress}");
+    assert!(
+        (progress - 0.0).abs() < 0.01,
+        "progress at t=0.5 should be ~0.0, got {progress}"
+    );
 
     let (progress, _) = tf.update_at(0.75);
-    assert!((progress - 0.5).abs() < 0.01, "progress at t=0.75 should be ~0.5, got {progress}");
+    assert!(
+        (progress - 0.5).abs() < 0.01,
+        "progress at t=0.75 should be ~0.5, got {progress}"
+    );
 
     let (progress, _) = tf.update_at(1.0);
-    assert!((progress - 1.0).abs() < 0.01, "progress at t=1.0 should be ~1.0, got {progress}");
+    assert!(
+        (progress - 1.0).abs() < 0.01,
+        "progress at t=1.0 should be ~1.0, got {progress}"
+    );
 }
 
 #[test]
@@ -66,7 +84,10 @@ fn keyframe_timing_done_with_start_offset() {
 
     // Animation starts at t=2.0, total duration is 1.0s
     assert!(!tf.done(2.0, 2.5), "should not be done 0.5s in");
-    assert!(tf.done(2.0, 3.0), "should be done at start + total_duration");
+    assert!(
+        tf.done(2.0, 3.0),
+        "should be done at start + total_duration"
+    );
 }
 
 #[test]
@@ -95,24 +116,39 @@ fn keyframe_three_segments() {
 
     // End of first segment
     let (progress, _) = tf.update_at(0.3);
-    assert!((progress - 0.3).abs() < 0.01, "end of seg 0: expected ~0.3, got {progress}");
+    assert!(
+        (progress - 0.3).abs() < 0.01,
+        "end of seg 0: expected ~0.3, got {progress}"
+    );
 
     // Middle of hold segment
     let (progress, _) = tf.update_at(0.4);
-    assert!((progress - 0.3).abs() < 0.01, "mid hold: expected ~0.3, got {progress}");
+    assert!(
+        (progress - 0.3).abs() < 0.01,
+        "mid hold: expected ~0.3, got {progress}"
+    );
 
     // End of hold segment
     let (progress, _) = tf.update_at(0.5);
-    assert!((progress - 0.3).abs() < 0.01, "end of hold: expected ~0.3, got {progress}");
+    assert!(
+        (progress - 0.3).abs() < 0.01,
+        "end of hold: expected ~0.3, got {progress}"
+    );
 
     // Middle of final segment (0.75s = 0.5 into a 0.5s segment = 50%)
     let (progress, _) = tf.update_at(0.75);
     let expected = 0.3 + (1.0 - 0.3) * 0.5; // 0.65
-    assert!((progress - expected).abs() < 0.01, "mid final: expected ~{expected}, got {progress}");
+    assert!(
+        (progress - expected).abs() < 0.01,
+        "mid final: expected ~{expected}, got {progress}"
+    );
 
     // End
     let (progress, _) = tf.update_at(1.0);
-    assert!((progress - 1.0).abs() < 0.01, "end: expected ~1.0, got {progress}");
+    assert!(
+        (progress - 1.0).abs() < 0.01,
+        "end: expected ~1.0, got {progress}"
+    );
 }
 
 #[test]
@@ -136,10 +172,16 @@ fn keyframe_empty_segments() {
 
     // Empty keyframes should immediately resolve
     let (progress, _) = tf.update_at(0.0);
-    assert!((progress - 1.0).abs() < 0.001, "empty keyframes should return 1.0");
+    assert!(
+        (progress - 1.0).abs() < 0.001,
+        "empty keyframes should return 1.0"
+    );
 
     let tf = TimingFunction::keyframes(vec![]);
-    assert!(tf.done(0.0, 0.0), "empty keyframes should be immediately done");
+    assert!(
+        tf.done(0.0, 0.0),
+        "empty keyframes should be immediately done"
+    );
 }
 
 #[test]
@@ -165,19 +207,23 @@ fn keyframe_single_segment() {
 #[test]
 fn keyframe_with_easing_curves() {
     // Use ease_in for first segment — progress should lag behind linear
-    let mut tf = TimingFunction::keyframes(vec![
-        KeyframeSegment {
-            duration: 1.0,
-            easing: Easing::ease_in(),
-            start_progress: 0.0,
-            end_progress: 1.0,
-        },
-    ]);
+    let mut tf = TimingFunction::keyframes(vec![KeyframeSegment {
+        duration: 1.0,
+        easing: Easing::ease_in(),
+        start_progress: 0.0,
+        end_progress: 1.0,
+    }]);
 
     let (progress, _) = tf.update_at(0.5);
     // ease_in at t=0.5 should be less than 0.5 (starts slow)
-    assert!(progress < 0.5, "ease_in at t=0.5 should be < 0.5, got {progress}");
-    assert!(progress > 0.0, "ease_in at t=0.5 should be > 0.0, got {progress}");
+    assert!(
+        progress < 0.5,
+        "ease_in at t=0.5 should be < 0.5, got {progress}"
+    );
+    assert!(
+        progress > 0.0,
+        "ease_in at t=0.5 should be > 0.0, got {progress}"
+    );
 }
 
 #[test]
@@ -190,10 +236,7 @@ fn keyframe_layer_integration() {
     let initial_pos = layer.position();
 
     // Hold for 0.5s, then animate to (100, 100) over 0.5s
-    layer.set_position(
-        (100.0, 100.0),
-        Transition::keyframes(hold_then_linear()),
-    );
+    layer.set_position((100.0, 100.0), Transition::keyframes(hold_then_linear()));
 
     // Advance 0.4s — still in hold segment, position should not change
     engine.update(0.2);

--- a/tests/keyframe_animations.rs
+++ b/tests/keyframe_animations.rs
@@ -278,7 +278,7 @@ fn keyframe_transition_constructor() {
     }]);
     assert_eq!(t.delay, 0.0);
     match t.timing {
-        TimingFunction::Keyframes(ref segments) => {
+        TimingFunction::Keyframes(ref segments, _) => {
             assert_eq!(segments.len(), 1);
             assert_eq!(segments[0].duration, 0.5);
         }


### PR DESCRIPTION
## Summary
- Add `TimingFunction::Keyframes` variant for piecewise animation timing with per-segment duration, easing, and progress ranges
- Add `KeyframeSegment` struct and `Transition::keyframes()` constructor
- Update `Transition` from `Copy` to `Clone` to support `Vec`-based keyframe segments
- Comprehensive test suite for keyframe timing, including edge cases and engine integration

## Test plan
- [x] Unit tests for hold, animate, multi-segment, easing, empty, and single-segment keyframes
- [x] Integration test with `Engine` for end-to-end keyframe animation
- [ ] Manual verification with example app