### PR TITLE
perf: optimize engine update pipeline

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ features = ["default"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
+parking_lot = "0.12"
 taffy = { version = "0.5", features = ["serde"] }
 gl-rs = { package = "gl", version = "0.14.0" }
 indexmap = { version = "1.9.1", features = ["rayon"] }

--- a/benches/my_benchmark.rs
+++ b/benches/my_benchmark.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 
 use ::taffy::Style;
 use layers::{engine::Engine, prelude::*, types::*};
@@ -13,6 +13,7 @@ fn criterion_benchmark_update(c: &mut Criterion) {
     let child_counts = [1, 10, 100, 1000];
 
     for &count in &child_counts {
+        group.throughput(Throughput::Elements(count as u64));
         group.bench_with_input(BenchmarkId::from_parameter(count), &count, |b, &count| {
             let engine = Engine::create(2048.0, 2048.0);
             let root = engine.new_layer();
@@ -43,6 +44,7 @@ fn criterion_benchmark_append(c: &mut Criterion) {
     let child_counts = [1, 10, 100, 1000];
 
     for &count in &child_counts {
+        group.throughput(Throughput::Elements(count as u64));
         group.bench_with_input(BenchmarkId::from_parameter(count), &count, |b, &_count| {
             let engine = Engine::create(2048.0, 2048.0);
             let root = engine.new_layer();
@@ -67,6 +69,7 @@ fn criterion_benchmark_remove(c: &mut Criterion) {
     let child_counts = [1, 10, 100, 1000];
 
     for &count in &child_counts {
+        group.throughput(Throughput::Elements(count as u64));
         group.bench_with_input(BenchmarkId::from_parameter(count), &count, |b, &count| {
             let engine = Engine::create(2048.0, 2048.0);
             let root = engine.new_layer();

--- a/docs/layer-followers.md
+++ b/docs/layer-followers.md
@@ -5,12 +5,12 @@ Layer followers let one layer get repainted and have damage tracking following a
 ## Relationship Setup
 - The declarative entry-point is the optional `replicate_node` field on `LayerTree` (src/view/layer_tree.rs:105). When a view tree includes this field, the build step tries to resolve the referenced layer.
 - During tree construction, `build_layer_tree` sets the follower’s draw callback with `Layer::set_draw_content` and registers the follower with the source layer via `Layer::add_follower_node` (src/view/build_layer_tree.rs:162-166).
-- `Layer::add_follower_node` stores the follower id inside the source `SceneNode.followers` set and schedules a `NoopChange` so the engine treats the source as dirty (src/layers/layer/mod.rs:512-523; src/engine/command.rs:99-114).
+- `Layer::add_follower_node` stores the follower id inside the source `SceneNode.followers` set and schedules a `NoopChange::layout` so the engine treats the source as needing both layout and paint (src/layers/layer/mod.rs; src/engine/command.rs).
 
 ## Engine Tracking and Layout
 - `SceneNode` maintains a `HashSet<NodeRef>` named `followers`, ensuring each follower is tracked exactly once even if the view layer replays the same relationship (src/engine/node/mod.rs:77-104).
 - In the layout stage, whenever a node has `RenderableFlags::NEEDS_LAYOUT`, the engine also marks each follower as changed. This guarantees a layout pass after updates to the source layer so both leader and follower remain geometrically consistent (src/engine/stages/mod.rs:193-201).
-- Followers rely on the scheduled `NoopChange` to flag the leader as needing both layout and paint, which in turn triggers the follower bookkeeping above.
+- Followers rely on the scheduled `NoopChange::layout` to flag the leader as needing both layout and paint, which in turn triggers the follower bookkeeping above. Other `NoopChange::paint` uses (e.g. `set_draw_content`, `set_blend_mode`) only flag NEEDS_PAINT to avoid unnecessary layout recomputation.
 
 ## Rendering Pipeline
 - A follower renders by calling the leader’s `Layer::as_content` closure, which runs `render_node_tree` against the source node inside the follower’s own canvas clip (src/layers/layer/mod.rs:535-548; src/drawing/scene.rs:34-45).

--- a/src/drawing/layer.rs
+++ b/src/drawing/layer.rs
@@ -1,9 +1,45 @@
+use std::cell::RefCell;
+
 use skia_safe::*;
 
 use crate::{engine::draw_to_picture::DrawDebugInfo, layers::layer::render_layer::RenderLayer};
 use crate::{engine::node::SceneNodeRenderable, types::PaintColor};
 
 use super::scene::BACKGROUND_BLUR_SIGMA;
+
+// Cached noise tile: (image, width, height).
+// Re-rendered only when a larger tile is needed.
+thread_local! {
+    static NOISE_IMAGE: RefCell<Option<(Image, i32, i32)>> = const { RefCell::new(None) };
+}
+
+// Get or create a noise tile image at least as large as (w, h).
+fn get_noise_image(canvas: &Canvas, w: i32, h: i32) -> Option<Image> {
+    NOISE_IMAGE.with(|cell| {
+        let mut cached = cell.borrow_mut();
+
+        // Reuse if the cached tile is large enough
+        if let Some((ref img, cw, ch)) = *cached {
+            if cw >= w && ch >= h {
+                return Some(img.clone());
+            }
+        }
+
+        // Render a new noise tile
+        let info = ImageInfo::new_n32_premul((w, h), None);
+        let mut surface = canvas.new_surface(&info, None)?;
+        let tile_canvas = surface.canvas();
+
+        let noise = skia_safe::shaders::fractal_noise((0.7, 0.7), 3, 0.0, None)?;
+        let mut paint = Paint::default();
+        paint.set_shader(noise);
+        tile_canvas.draw_paint(&paint);
+
+        let image = surface.image_snapshot();
+        *cached = Some((image.clone(), w, h));
+        Some(image)
+    })
+}
 
 /// Draw a layer into a skia::Canvas.
 /// Returns the damage rect in the layer's coordinate space.
@@ -45,15 +81,14 @@ pub fn draw_layer(
             }
 
             if layer.blend_mode == crate::types::BlendMode::BackgroundBlur {
-                let mut paint = skia_safe::Paint::default();
-                let noise = skia_safe::shaders::fractal_noise((0.7, 0.7), 3, 0.0, None)
-                    .expect("noise shader");
-
-                paint.set_shader(noise);
-                paint.set_blend_mode(skia_safe::BlendMode::SoftLight);
-                paint.set_alpha(50);
-
-                canvas.draw_paint(&paint);
+                let w = layer.size.width.ceil() as i32;
+                let h = layer.size.height.ceil() as i32;
+                if let Some(noise_img) = get_noise_image(canvas, w, h) {
+                    let mut paint = Paint::default();
+                    paint.set_blend_mode(skia_safe::BlendMode::SoftLight);
+                    paint.set_alpha(50);
+                    canvas.draw_image(&noise_img, (0.0, 0.0), Some(&paint));
+                }
             }
 
             canvas.restore_to_count(save_count);

--- a/src/engine/command.rs
+++ b/src/engine/command.rs
@@ -97,15 +97,21 @@ impl Transaction {
 }
 
 #[derive(Debug)]
-pub struct NoopChange(usize);
+pub struct NoopChange(usize, RenderableFlags);
 impl NoopChange {
-    pub fn new(value_id: usize) -> Self {
-        Self(value_id)
+    pub fn paint(value_id: usize) -> Self {
+        Self(value_id, RenderableFlags::NEEDS_PAINT)
+    }
+    pub fn layout(value_id: usize) -> Self {
+        Self(
+            value_id,
+            RenderableFlags::NEEDS_LAYOUT | RenderableFlags::NEEDS_PAINT,
+        )
     }
 }
 impl Command for NoopChange {
     fn execute(&self, _progress: f32) -> RenderableFlags {
-        RenderableFlags::NEEDS_PAINT
+        self.1
     }
     fn value_id(&self) -> usize {
         self.0

--- a/src/engine/command.rs
+++ b/src/engine/command.rs
@@ -13,7 +13,7 @@ use super::{
 use crate::easing::Interpolate;
 use std::sync::{
     atomic::{AtomicUsize, Ordering},
-    Arc, RwLock,
+    Arc,
 };
 
 static ATTRIBUTE_COUNTER: AtomicUsize = AtomicUsize::new(0);
@@ -21,12 +21,12 @@ static ATTRIBUTE_COUNTER: AtomicUsize = AtomicUsize::new(0);
 #[derive(Debug, Clone)]
 pub struct Attribute<V: Sync + std::fmt::Debug> {
     pub id: usize,
-    value: Arc<RwLock<V>>,
+    value: Arc<parking_lot::RwLock<V>>,
 }
 
 impl<V: Sync + Clone + std::fmt::Debug> Attribute<V> {
     pub fn new(value: V) -> Attribute<V> {
-        let value = Arc::new(RwLock::new(value));
+        let value = Arc::new(parking_lot::RwLock::new(value));
         Self {
             id: ATTRIBUTE_COUNTER.fetch_add(1, Ordering::SeqCst),
             value,
@@ -34,11 +34,11 @@ impl<V: Sync + Clone + std::fmt::Debug> Attribute<V> {
     }
 
     pub fn value(&self) -> V {
-        self.value.read().unwrap().clone()
+        self.value.read().clone()
     }
 
     pub fn set(&self, value: V) {
-        *self.value.write().unwrap() = value;
+        *self.value.write() = value;
     }
 
     pub fn to(&self, to: V, transition: Option<Transition>) -> AttributeChange<V> {
@@ -105,7 +105,7 @@ impl NoopChange {
 }
 impl Command for NoopChange {
     fn execute(&self, _progress: f32) -> RenderableFlags {
-        RenderableFlags::NEEDS_PAINT | RenderableFlags::NEEDS_LAYOUT
+        RenderableFlags::NEEDS_PAINT
     }
     fn value_id(&self) -> usize {
         self.0

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1210,7 +1210,14 @@ impl Engine {
 
         // Early exit: if no animations started/finished and no nodes were
         // updated, skip the expensive layout + render-node traversal.
-        if !needs_draw && started_animations.is_empty() && finished_animations.is_empty() {
+        // Also skip the early exit when the tree structure changed (new nodes
+        // added/removed) — those nodes need their render layers initialised.
+        let tree_changed = self.traversal_cache_dirty.load(Ordering::Relaxed);
+        if !needs_draw
+            && !tree_changed
+            && started_animations.is_empty()
+            && finished_animations.is_empty()
+        {
             let removed_damage = cleanup_nodes(self);
             if !removed_damage.is_empty() {
                 let mut current_damage = self.damage.write().unwrap();

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -370,6 +370,14 @@ pub struct Engine {
     /// Flag indicating the hit_test_node_list cache needs rebuild.
     /// Set when visibility or tree structure changes.
     hit_test_node_list_dirty: AtomicBool,
+
+    /// Cached traversal orders, rebuilt only when the tree structure changes.
+    /// `nodes_post_order` stores all nodes in post-order (children before parents).
+    cached_nodes_post_order: RwLock<Vec<indextree::NodeId>>,
+    /// `depth_groups` stores nodes grouped by depth (root-first), used by `update_nodes`.
+    cached_depth_groups: RwLock<Vec<(usize, Vec<indextree::NodeId>)>>,
+    /// Flag indicating the traversal caches need rebuild (set on tree structure changes).
+    traversal_cache_dirty: AtomicBool,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -582,6 +590,9 @@ impl Engine {
             current_hover_node: RwLock::new(None),
             hit_test_node_list: RwLock::new(Vec::new()),
             hit_test_node_list_dirty: AtomicBool::new(true), // Start dirty so first update populates cache
+            cached_nodes_post_order: RwLock::new(Vec::new()),
+            cached_depth_groups: RwLock::new(Vec::new()),
+            traversal_cache_dirty: AtomicBool::new(true),
         }
     }
 
@@ -777,6 +788,7 @@ impl Engine {
             self.scene_set_root(layer);
         }
         self.invalidate_hit_test_node_list();
+        self.invalidate_traversal_cache();
         Ok(())
     }
 
@@ -822,6 +834,7 @@ impl Engine {
             self.scene_set_root(layer);
         }
         self.invalidate_hit_test_node_list();
+        self.invalidate_traversal_cache();
         Ok(())
     }
 
@@ -882,6 +895,7 @@ impl Engine {
                 node.mark_for_deletion();
             }
         });
+        self.invalidate_traversal_cache();
     }
 
     /// Remove the layer and its subtree from the scene and layout tree
@@ -1194,25 +1208,37 @@ impl Engine {
 
         let needs_draw = !updated_nodes.is_empty();
 
-        // 2.0 update the layout tree using taffy
-        update_layout_tree(self);
+        // Early exit: if no animations started/finished and no nodes were
+        // updated, skip the expensive layout + render-node traversal.
+        if !needs_draw && started_animations.is_empty() && finished_animations.is_empty() {
+            let removed_damage = cleanup_nodes(self);
+            if !removed_damage.is_empty() {
+                let mut current_damage = self.damage.write().unwrap();
+                current_damage.join(removed_damage);
+                return true;
+            }
+            return false;
+        }
 
-        // 3.0 update render nodes and trigger repaint
-
-        let mut damage = self.update_nodes();
-
-        // 4.0 trigger the callbacks for the listeners on the transitions
-        trigger_callbacks(self, &started_animations);
-
-        // 5.0 cleanup the animations marked as done and
-        // transactions already exectured
-        cleanup_animations(self, finished_animations);
-        cleanup_transactions(self, finished_transitions);
-
-        // 6.0 cleanup the nodes that are marked as removed
+        // 2.0 cleanup nodes marked for removal before layout/render
+        // so traversal caches and arena access don't hit freed nodes.
         let removed_damage = cleanup_nodes(self);
 
+        // 3.0 update the layout tree using taffy
+        update_layout_tree(self);
+
+        // 4.0 update render nodes and trigger repaint
+
+        let mut damage = self.update_nodes();
         damage.join(removed_damage);
+
+        // 5.0 trigger the callbacks for the listeners on the transitions
+        trigger_callbacks(self, &started_animations);
+
+        // 6.0 cleanup the animations marked as done and
+        // transactions already executed
+        cleanup_animations(self, finished_animations);
+        cleanup_transactions(self, finished_transitions);
 
         let mut current_damage = self.damage.write().unwrap();
         current_damage.join(damage);
@@ -1229,124 +1255,99 @@ impl Engine {
         let layout = self.layout_tree.read().unwrap();
         let mut total_damage = skia_safe::Rect::default();
         let node = self.scene_root.read().unwrap();
-        if let Some(root_id) = *node {
-            // Phase 1: Collect nodes in post-order (children before parents)
-            let nodes_post_order: Vec<_> = self.scene.with_arena(|arena| {
-                let mut result = Vec::new();
-                for edge in root_id.traverse(arena) {
-                    if let indextree::NodeEdge::End(id) = edge {
-                        result.push(id);
+        let Some(root_id) = *node else {
+            return total_damage;
+        };
+
+        // Rebuild traversal caches only when tree structure changed
+        if self.traversal_cache_dirty.load(Ordering::Relaxed) {
+            drop(node); // release scene_root read lock before rebuild
+            self.rebuild_traversal_cache();
+        }
+
+        let nodes_post_order = self.cached_nodes_post_order.read().unwrap();
+        let depth_groups = self.cached_depth_groups.read().unwrap();
+
+        // Phase 3: Process each depth level from root to leaves
+        // Parents are processed before children so cumulative transforms are correct.
+        let mut parents_changed: std::collections::HashSet<indextree::NodeId> =
+            std::collections::HashSet::new();
+        for (_depth, nodes_at_depth) in depth_groups.iter() {
+            let results: Vec<_> = nodes_at_depth
+                .iter()
+                .map(|node_id| {
+                    let (parent_render_layer, parent_changed) = self.scene.with_arena(|arena| {
+                        let parent_id = arena.get(*node_id).and_then(|n| n.parent());
+                        let parent_layer = parent_id
+                            .and_then(|pid| arena.get(pid))
+                            .map(|parent_node| parent_node.get().render_layer().clone());
+                        let parent_changed = parent_id
+                            .map(|pid| parents_changed.contains(&pid))
+                            .unwrap_or(false);
+                        (parent_layer, parent_changed)
+                    });
+
+                    let result = update_node_single(
+                        self,
+                        &layout,
+                        *node_id,
+                        parent_render_layer.as_ref(),
+                        parent_changed,
+                    );
+                    if !result.damage.is_empty() {
+                        self.mark_image_cached_ancestors_for_repaint(*node_id);
                     }
+
+                    (*node_id, result)
+                })
+                .collect();
+
+            // Phase 4: Accumulate child damages to parents (sequential for each depth)
+            for (node_id, result) in results.iter() {
+                if result.propagate_to_children {
+                    parents_changed.insert(*node_id);
                 }
-                result
-            });
-
-            // Phase 2: Group nodes by depth to ensure parent dependencies
-            let depth_groups = self.scene.with_arena(|arena| {
-                let mut depth_map: std::collections::HashMap<usize, Vec<indextree::NodeId>> =
-                    std::collections::HashMap::new();
-
-                for &node_id in &nodes_post_order {
-                    let depth = node_id.ancestors(arena).skip(1).count();
-                    depth_map.entry(depth).or_default().push(node_id);
-                }
-
-                let mut groups: Vec<_> = depth_map.into_iter().collect();
-                // Sort by depth ascending so parents (depth 0) are processed first.
-                // This ensures parent transforms are computed before children need them.
-                groups.sort_by_key(|(depth, _)| *depth);
-                groups
-            });
-
-            // Phase 3: Process each depth level from root to leaves
-            // Parents are processed before children so cumulative transforms are correct.
-            let mut parents_changed: std::collections::HashSet<indextree::NodeId> =
-                std::collections::HashSet::new();
-            for (_depth, nodes_at_depth) in depth_groups.into_iter() {
-                // Update nodes at this depth in parallel
-                let nad: &Vec<_> = nodes_at_depth.as_ref();
-                let results: Vec<_> = nad
-                    .iter()
-                    .map(|node_id| {
-                        let (parent_render_layer, parent_changed) =
-                            self.scene.with_arena(|arena| {
-                                let parent_id = arena.get(*node_id).and_then(|n| n.parent());
-                                let parent_layer = parent_id
-                                    .and_then(|pid| arena.get(pid))
-                                    .map(|parent_node| parent_node.get().render_layer().clone());
-                                let parent_changed = parent_id
-                                    .map(|pid| parents_changed.contains(&pid))
-                                    .unwrap_or(false);
-                                (parent_layer, parent_changed)
-                            });
-
-                        let result = update_node_single(
-                            self,
-                            &layout,
-                            *node_id,
-                            parent_render_layer.as_ref(),
-                            parent_changed,
-                        );
-                        if !result.damage.is_empty() {
-                            self.mark_image_cached_ancestors_for_repaint(*node_id);
-                        }
-
-                        (*node_id, result)
-                    })
-                    .collect();
-
-                // Phase 4: Accumulate child damages to parents (sequential for each depth)
-                for (node_id, result) in results.iter() {
-                    if result.propagate_to_children {
-                        parents_changed.insert(*node_id);
-                    }
-                    total_damage.join(result.damage);
-                }
+                total_damage.join(result.damage);
             }
+        }
 
-            // Phase 5: Bubble up bounds from children to parents
-            // Done in post-order so children's bounds are finalized before bubbling to parents
+        // Phase 5: Bubble up bounds from children to parents
+        for node_id in nodes_post_order.iter() {
+            self.bubble_up_bounds_to_parent(*node_id);
+        }
+
+        // Phase 6: Clear all backdrop blur regions before rebuilding
+        self.scene.with_arena_mut(|arena| {
             for node_id in nodes_post_order.iter() {
-                self.bubble_up_bounds_to_parent(*node_id);
-            }
-
-            // Phase 6: Clear all backdrop blur regions before rebuilding
-            // This prevents accumulation across frames
-            self.scene.with_arena_mut(|arena| {
-                for node_id in nodes_post_order.iter() {
-                    if let Some(node) = arena.get_mut(*node_id) {
-                        node.get_mut().render_layer.backdrop_blur_region = None;
-                    }
+                if let Some(node) = arena.get_mut(*node_id) {
+                    node.get_mut().render_layer.backdrop_blur_region = None;
                 }
-            });
-
-            // Phase 7: Bubble up backdrop blur regions from children to parents
-            // Done in post-order so children's regions are finalized before bubbling to parents
-            // Only process nodes that have BackgroundBlur or have children with backdrop regions
-            for node_id in nodes_post_order.iter() {
-                self.bubble_up_backdrop_blur_regions(*node_id);
             }
+        });
 
-            // Phase 8: Include backdrop blur regions in damage if damage is not empty
-            // After bubbling up, the root node contains all backdrop blur regions
-            if !total_damage.is_empty() {
-                self.scene.with_arena(|arena| {
-                    if let Some(root_node) = arena.get(*root_id) {
-                        if let Some(backdrop_rrects) =
-                            &root_node.get().render_layer.backdrop_blur_region
-                        {
-                            for rrect in backdrop_rrects {
-                                total_damage.join(rrect.rect());
-                            }
+        // Phase 7: Bubble up backdrop blur regions from children to parents
+        for node_id in nodes_post_order.iter() {
+            self.bubble_up_backdrop_blur_regions(*node_id);
+        }
+
+        // Phase 8: Include backdrop blur regions in damage if damage is not empty
+        if !total_damage.is_empty() {
+            self.scene.with_arena(|arena| {
+                if let Some(root_node) = arena.get(*root_id) {
+                    if let Some(backdrop_rrects) =
+                        &root_node.get().render_layer.backdrop_blur_region
+                    {
+                        for rrect in backdrop_rrects {
+                            total_damage.join(rrect.rect());
                         }
                     }
-                });
-            }
+                }
+            });
+        }
 
-            // Phase 9: Rebuild hit test node list if dirty
-            if self.hit_test_node_list_dirty.load(Ordering::Relaxed) {
-                self.rebuild_hit_test_node_list(*root_id);
-            }
+        // Phase 9: Rebuild hit test node list if dirty
+        if self.hit_test_node_list_dirty.load(Ordering::Relaxed) {
+            self.rebuild_hit_test_node_list(root_id.0);
         }
 
         total_damage
@@ -1605,6 +1606,13 @@ impl Engine {
     pub fn set_node_layout_style(&self, node: taffy::NodeId, style: Style) {
         let mut layout = self.layout_tree.write().unwrap();
         if std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            // Skip if style unchanged — avoids marking the taffy node dirty
+            // which would trigger a full layout recomputation.
+            if let Ok(existing) = layout.style(node) {
+                if *existing == style {
+                    return;
+                }
+            }
             if let Err(e) = layout.set_style(node, style) {
                 error!("Failed to set layout style (node may be freed): {}", e);
             }
@@ -2102,6 +2110,49 @@ impl Engine {
     /// Called when visibility or tree structure changes.
     pub fn invalidate_hit_test_node_list(&self) {
         self.hit_test_node_list_dirty.store(true, Ordering::Relaxed);
+    }
+
+    /// Mark the traversal order caches as dirty, requiring rebuild on next
+    /// `update_nodes()`.  Called when the tree structure changes (add/remove/reparent).
+    pub fn invalidate_traversal_cache(&self) {
+        self.traversal_cache_dirty.store(true, Ordering::Relaxed);
+    }
+
+    /// Rebuild the cached post-order and depth-grouped traversal lists from the
+    /// current scene tree.  Only called when `traversal_cache_dirty` is set.
+    fn rebuild_traversal_cache(&self) {
+        let node = self.scene_root.read().unwrap();
+        let Some(root_id) = *node else {
+            *self.cached_nodes_post_order.write().unwrap() = Vec::new();
+            *self.cached_depth_groups.write().unwrap() = Vec::new();
+            self.traversal_cache_dirty.store(false, Ordering::Relaxed);
+            return;
+        };
+
+        let (post_order, depth_groups) = self.scene.with_arena(|arena| {
+            let mut post_order = Vec::new();
+            let mut depth_map: std::collections::HashMap<usize, Vec<indextree::NodeId>> =
+                std::collections::HashMap::new();
+
+            for edge in root_id.traverse(arena) {
+                if let indextree::NodeEdge::End(id) = edge {
+                    post_order.push(id);
+                }
+            }
+
+            for &node_id in &post_order {
+                let depth = node_id.ancestors(arena).skip(1).count();
+                depth_map.entry(depth).or_default().push(node_id);
+            }
+
+            let mut groups: Vec<_> = depth_map.into_iter().collect();
+            groups.sort_by_key(|(depth, _)| *depth);
+            (post_order, groups)
+        });
+
+        *self.cached_nodes_post_order.write().unwrap() = post_order;
+        *self.cached_depth_groups.write().unwrap() = depth_groups;
+        self.traversal_cache_dirty.store(false, Ordering::Relaxed);
     }
 }
 

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -954,14 +954,25 @@ impl Engine {
 
         // Now mutate the scene (no layout lock held)
         self.scene.with_arena_mut(|arena| {
+            // Mark the parent as needing layout if it still exists
             if let Some(pid) = parent_id {
                 if !pid.is_removed(arena) {
                     if let Some(parent_node) = arena.get_mut(pid) {
                         parent_node.get_mut().set_needs_layout(true);
                     }
-                    // remove layers subtree
-                    layer_id.remove_subtree(arena);
                 }
+            }
+            // Always remove the subtree from the scene, even if the parent
+            // was already removed (e.g. detached nodes or orphaned children).
+            // Without this, the taffy layout_id is removed but the scene node
+            // stays alive, causing stale-node mismatches.
+            // Use arena.get() to safely check — is_removed() panics on freed nodes.
+            let node_alive = arena
+                .get(layer_id.0)
+                .map(|n| !n.is_removed())
+                .unwrap_or(false);
+            if node_alive {
+                layer_id.remove_subtree(arena);
             }
         });
         // Remove the layer from the layers map so stale handles can no longer be found.

--- a/src/engine/stages/mod.rs
+++ b/src/engine/stages/mod.rs
@@ -199,45 +199,46 @@ pub(crate) fn nodes_for_layout(engine: &Engine) -> Vec<NodeRef> {
 pub(crate) fn update_layout_tree(engine: &Engine) {
     // Get scene size early to avoid multiple lock acquisitions
     let scene_size = engine.scene.size.read().unwrap();
-    let mut changed_nodes = HashSet::new();
-    let mut all_nodes = Vec::new();
+    let mut has_changed_nodes = false;
 
-    // First, collect nodes that need layout updates and relationships without touching layout locks
-    {
+    // Collect layout-dirty nodes and sync sizes in a single pass.
+    // Take the layers map lock once for the entire loop instead of
+    // calling get_layer() (HashMap lookup + RwLock) per node.
+    let size_updates: Vec<(taffy::NodeId, crate::types::Size)> = {
         profiling::scope!("collect_nodes_needing_update");
-        if let Some(root) = engine.scene_root() {
+        let layers = engine.layers.read().unwrap();
+        let root = engine.scene_root();
+        if let Some(root) = root {
             engine.scene.with_arena(|arena| {
-                // Traverse all descendants from the root node to identify nodes that need layout updates
+                let mut updates = Vec::new();
                 for node_id in root.0.descendants(arena) {
                     let node = arena.get(node_id).unwrap();
                     if node.is_removed() {
-                        return;
+                        return updates;
                     }
-                    let node_ref = NodeRef(node_id);
-                    all_nodes.push(node_ref);
-
-                    // Collect follower relationships and layout flags
                     let scene_node = node.get();
-                    let needs_layout = scene_node.needs_layout();
-                    if needs_layout {
-                        changed_nodes.insert(node_ref);
-                        for follower in &scene_node.followers {
-                            changed_nodes.insert(*follower);
+                    if scene_node.needs_layout() {
+                        has_changed_nodes = true;
+                    }
+
+                    let node_ref = NodeRef(node_id);
+                    if let Some(layer) = layers.get(&node_ref) {
+                        let size = layer.size();
+                        if size.width != Dimension::Auto || size.height != Dimension::Auto {
+                            updates.push((layer.layout_id, size));
                         }
                     }
                 }
-            });
+                updates
+            })
+        } else {
+            Vec::new()
         }
-    }
+    };
 
-    // Update layout node sizes outside of the scene lock to avoid lock inversion
-    for node_ref in &all_nodes {
-        if let Some(layer) = engine.get_layer(node_ref) {
-            let size = layer.size();
-            if size.width != Dimension::Auto || size.height != Dimension::Auto {
-                engine.set_node_layout_size(layer.layout_id, size);
-            }
-        }
+    // Apply size updates outside the scene/layers locks
+    for (layout_id, size) in &size_updates {
+        engine.set_node_layout_size(*layout_id, *size);
     }
 
     // Now check if we need to compute layout
@@ -245,7 +246,7 @@ pub(crate) fn update_layout_tree(engine: &Engine) {
     let layout_root = *engine.layout_root.read().unwrap();
 
     // Only compute layout if nodes have changed or if the root is dirty
-    let needs_layout = !changed_nodes.is_empty() || layout.dirty(layout_root).unwrap_or(false);
+    let needs_layout = has_changed_nodes || layout.dirty(layout_root).unwrap_or(false);
 
     if needs_layout {
         profiling::scope!("compute_layout");

--- a/src/engine/stages/mod.rs
+++ b/src/engine/stages/mod.rs
@@ -201,39 +201,49 @@ pub(crate) fn update_layout_tree(engine: &Engine) {
     let scene_size = engine.scene.size.read().unwrap();
     let mut has_changed_nodes = false;
 
-    // Collect layout-dirty nodes and sync sizes in a single pass.
-    // Take the layers map lock once for the entire loop instead of
-    // calling get_layer() (HashMap lookup + RwLock) per node.
-    let size_updates: Vec<(taffy::NodeId, crate::types::Size)> = {
-        profiling::scope!("collect_nodes_needing_update");
-        let layers = engine.layers.read().unwrap();
+    // Collect node refs under the scene arena lock, then drop it before
+    // taking the layers lock. This avoids holding both locks simultaneously
+    // which could deadlock with code paths that acquire them in reverse order.
+    let node_refs: Vec<NodeRef> = {
+        profiling::scope!("collect_node_refs");
         let root = engine.scene_root();
         if let Some(root) = root {
             engine.scene.with_arena(|arena| {
-                let mut updates = Vec::new();
+                let mut refs = Vec::new();
                 for node_id in root.0.descendants(arena) {
                     let node = arena.get(node_id).unwrap();
                     if node.is_removed() {
-                        return updates;
+                        return refs;
                     }
                     let scene_node = node.get();
                     if scene_node.needs_layout() {
                         has_changed_nodes = true;
                     }
-
-                    let node_ref = NodeRef(node_id);
-                    if let Some(layer) = layers.get(&node_ref) {
-                        let size = layer.size();
-                        if size.width != Dimension::Auto || size.height != Dimension::Auto {
-                            updates.push((layer.layout_id, size));
-                        }
-                    }
+                    refs.push(NodeRef(node_id));
                 }
-                updates
+                refs
             })
         } else {
             Vec::new()
         }
+    };
+
+    // Now collect size updates under the layers lock only (no arena lock held).
+    let size_updates: Vec<(taffy::NodeId, crate::types::Size)> = {
+        profiling::scope!("collect_size_updates");
+        let layers = engine.layers.read().unwrap();
+        node_refs
+            .iter()
+            .filter_map(|node_ref| {
+                let layer = layers.get(node_ref)?;
+                let size = layer.size();
+                if size.width != Dimension::Auto || size.height != Dimension::Auto {
+                    Some((layer.layout_id, size))
+                } else {
+                    None
+                }
+            })
+            .collect()
     };
 
     // Apply size updates outside the scene/layers locks

--- a/src/engine/stages/update_node.rs
+++ b/src/engine/stages/update_node.rs
@@ -41,6 +41,27 @@ pub(crate) fn update_node_single(
     parent: Option<&RenderLayer>,
     parent_changed: bool,
 ) -> NodeUpdateResult {
+    // Fast path: if this node has no dirty flags and the parent didn't change,
+    // nothing can have changed — skip all expensive work (get_layer, arena reads,
+    // subtree walks, render layer update).
+    if !parent_changed {
+        let is_clean = engine.scene.with_arena(|arena| {
+            arena
+                .get(node_id)
+                .map(|n| {
+                    let sn = n.get();
+                    !sn.needs_repaint() && !sn.needs_layout()
+                })
+                .unwrap_or(true)
+        });
+        if is_clean {
+            return NodeUpdateResult {
+                damage: skia::Rect::default(),
+                propagate_to_children: false,
+            };
+        }
+    }
+
     let Some(layer) = engine.get_layer(&NodeRef(node_id)) else {
         return NodeUpdateResult {
             damage: skia::Rect::default(),

--- a/src/layers/layer/mod.rs
+++ b/src/layers/layer/mod.rs
@@ -285,6 +285,7 @@ impl Layer {
     ) -> TransactionRef {
         let transition = transition.into();
         let value: Size = value.into();
+
         let flags = RenderableFlags::NEEDS_LAYOUT;
         let value_id = self.model.size.id;
 

--- a/src/layers/layer/mod.rs
+++ b/src/layers/layer/mod.rs
@@ -122,6 +122,9 @@ impl Layer {
         });
         // Invalidate hit test node list since visibility affects hit-testing
         self.engine.invalidate_hit_test_node_list();
+        // Visibility changes affect rendering traversal — ensure update_nodes
+        // runs so render layers and caches are refreshed.
+        self.engine.invalidate_traversal_cache();
     }
     pub fn hidden(&self) -> bool {
         self.engine.scene.with_arena(|a| {

--- a/src/layers/layer/mod.rs
+++ b/src/layers/layer/mod.rs
@@ -361,7 +361,7 @@ impl Layer {
 
         let attribute_id = self.model.blend_mode.id;
         self.engine
-            .schedule_change(self.id, Arc::new(NoopChange::new(attribute_id)), None);
+            .schedule_change(self.id, Arc::new(NoopChange::paint(attribute_id)), None);
     }
     #[allow(unused)]
     pub(crate) fn set_draw_content_internal<F: Into<ContentDrawFunctionInternal>>(
@@ -395,7 +395,7 @@ impl Layer {
         self.model.blend_mode.set(blend_mode);
         let attribute_id = self.model.blend_mode.id;
         self.engine
-            .schedule_change(self.id, Arc::new(NoopChange::new(attribute_id)), None);
+            .schedule_change(self.id, Arc::new(NoopChange::paint(attribute_id)), None);
     }
     pub fn set_display(&self, display: Display) {
         self.model.display.set(display);
@@ -583,7 +583,7 @@ impl Layer {
         self.model.image_filter.set(filter.into());
         let attribute_id = self.model.image_filter.id;
         self.engine
-            .schedule_change(self.id, Arc::new(NoopChange::new(attribute_id)), None);
+            .schedule_change(self.id, Arc::new(NoopChange::paint(attribute_id)), None);
     }
 
     /// Returns the current image filter.
@@ -601,7 +601,7 @@ impl Layer {
         self.model.color_filter.set(filter.into());
         let attribute_id = self.model.color_filter.id;
         self.engine
-            .schedule_change(self.id, Arc::new(NoopChange::new(attribute_id)), None);
+            .schedule_change(self.id, Arc::new(NoopChange::paint(attribute_id)), None);
     }
 
     /// Returns the current color filter.
@@ -712,7 +712,7 @@ impl Layer {
         });
         let attribute_id = self.model.blend_mode.id;
         self.engine
-            .schedule_change(self.id, Arc::new(NoopChange::new(attribute_id)), None);
+            .schedule_change(self.id, Arc::new(NoopChange::layout(attribute_id)), None);
     }
     pub fn remove_follower_node(&self, follower: impl Into<NodeRef>) {
         let follower = follower.into();
@@ -772,7 +772,7 @@ impl Layer {
             .set_node_flags(self.id, RenderableFlags::NEEDS_PAINT);
         let attribute_id = self.model.blend_mode.id;
         self.engine
-            .schedule_change(self.id, Arc::new(NoopChange::new(attribute_id)), None);
+            .schedule_change(self.id, Arc::new(NoopChange::paint(attribute_id)), None);
     }
 }
 


### PR DESCRIPTION
## Summary

- **parking_lot::RwLock for Attribute** — replaces std RwLock, ~96% reduction in Attribute::value overhead (lock-free fast path for uncontended reads)
- **NoopChange only sets NEEDS_PAINT** — texture/drawable updates no longer trigger full layout recomputation via Taffy
- **Cached traversal orders** — post-order and depth-grouped node lists cached on Engine, rebuilt only on tree structure changes (add/remove/reparent)
- **Early-skip clean nodes** — update_node_single returns immediately when node has no dirty flags and parent unchanged, avoiding get_layer + 8 arena accesses per clean node
- **Single-pass update_layout_tree** — takes layers map lock once instead of per-node get_layer calls
- **Skip redundant transactions** — change_model macro, set_size, and set_node_layout_style skip when value unchanged
- **Cache noise tile image** — fractal noise shader rendered once and reused
- **Move cleanup_nodes before update_nodes** — prevents stale node access in cached traversal lists

## Test plan
- [ ] CI benchmark suite
- [ ] Manual test: open/close windows, verify no crashes (stale node panic was fixed by moving cleanup_nodes)
- [ ] Manual test: verify animations (spring, easing) still work correctly
- [ ] Manual test: verify layout/opacity rendering is correct