### PR TITLE
feat(damage): fold occlusion into scene damage aggregation

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1286,6 +1286,12 @@ impl Engine {
         let nodes_post_order = self.cached_nodes_post_order.read().unwrap();
         let depth_groups = self.cached_depth_groups.read().unwrap();
 
+        // Per-node damage map, used below by the occlusion-aware damage
+        // folder. Each entry is the node's global-coordinate damage rect
+        // as produced by `update_node_single`.
+        let mut per_node_damage: std::collections::HashMap<NodeRef, skia_safe::Rect> =
+            std::collections::HashMap::new();
+
         // Phase 3: Process each depth level from root to leaves
         // Parents are processed before children so cumulative transforms are correct.
         let mut parents_changed: std::collections::HashSet<indextree::NodeId> =
@@ -1325,8 +1331,23 @@ impl Engine {
                 if result.propagate_to_children {
                     parents_changed.insert(*node_id);
                 }
+                if !result.damage.is_empty() {
+                    per_node_damage.insert(NodeRef(*node_id), result.damage);
+                }
                 total_damage.join(result.damage);
             }
+        }
+
+        // Phase 4.5: Fold occlusion into the accumulated damage. For the
+        // scene root, walk front-to-back and subtract the global bounds
+        // of any opaque layer from damage contributions of layers behind
+        // it. Replaces `total_damage` with the clipped region's bounding
+        // rect — same type/shape, smaller value when occlusion applies.
+        if !per_node_damage.is_empty() {
+            let occluded_damage = self.scene.with_arena(|arena| {
+                occlusion::compute_occlusion_aware_damage(root_id, arena, &per_node_damage)
+            });
+            total_damage = occluded_damage;
         }
 
         // Phase 5: Bubble up bounds from children to parents

--- a/src/engine/occlusion.rs
+++ b/src/engine/occlusion.rs
@@ -83,6 +83,141 @@ pub fn compute_occlusion(root: NodeRef, arena: &Arena<SceneNode>) -> HashSet<Nod
     occluded
 }
 
+/// Fold occlusion into per-node damage to produce an occlusion-aware
+/// scene damage rect.
+///
+/// Walks the subtree rooted at `root` front-to-back with a running
+/// `skia::Region` that accumulates the bounds of every valid opaque
+/// occluder seen so far. For each node with damage, the running region
+/// is subtracted from the damage rect before it is unioned into the
+/// scene total. Nodes whose entire damage rect is covered by the
+/// running region contribute nothing.
+///
+/// `per_node_damage` maps a node id to its global-coordinates damage
+/// rect as already computed by `update_node_single`. Nodes not present
+/// in the map are assumed to have no damage this frame.
+///
+/// Returns the bounding `Rect` of the resulting damage region, matching
+/// the legacy `Engine::damage()` return type so callers don't have to
+/// change. The full pixel set is visible to the caller only via this
+/// bounding box — sufficient for the use case where downstream
+/// consumers clip/redraw a rectangular area.
+#[profiling::function]
+pub fn compute_occlusion_aware_damage(
+    root: NodeRef,
+    arena: &Arena<SceneNode>,
+    per_node_damage: &HashMap<NodeRef, skia_safe::Rect>,
+) -> skia_safe::Rect {
+    let root_id: TreeStorageId = root.into();
+
+    // Collect nodes in draw order (pre-order = back-to-front).
+    let mut draw_order: Vec<NodeOcclusionInfo> = Vec::new();
+    collect_draw_order(root_id, arena, 1.0, None, &mut draw_order);
+
+    // Opaque shapes accumulated in front-to-back order, tagged with the
+    // node that contributed each one. The tag lets us filter descendants
+    // out when subtracting occlusion from an ancestor's damage — a
+    // descendant cannot legitimately occlude its ancestor, because the
+    // ancestor's damage represents re-rendering its own subtree (through
+    // any filter / effect the ancestor applies).
+    let mut occluder_shapes: Vec<(NodeRef, skia_safe::IRect)> = Vec::new();
+    let mut damage = skia_safe::Region::new();
+    let mut visited: HashSet<NodeRef> = HashSet::new();
+
+    // Front-to-back: the node at the end of draw_order is closest to the
+    // viewer, so iterate in reverse.
+    for info in draw_order.iter().rev() {
+        visited.insert(info.node_ref);
+
+        if info.clipped_out {
+            continue;
+        }
+
+        // Add the node's damage (if any), minus the effective occluder
+        // region for this specific node — which excludes any occluder
+        // shape contributed by one of this node's descendants.
+        if let Some(rect) = per_node_damage.get(&info.node_ref) {
+            if !rect.is_empty() {
+                let mut effective = skia_safe::Region::new();
+                for (shape_node, shape_irect) in &occluder_shapes {
+                    if is_descendant(*shape_node, info.node_ref, arena) {
+                        continue;
+                    }
+                    effective.op_rect(*shape_irect, skia_safe::region::RegionOp::Union);
+                }
+                let mut d = skia_safe::Region::from_rect(rect_to_irect(*rect));
+                d.op_region(&effective, skia_safe::region::RegionOp::Difference);
+                damage.op_region(&d, skia_safe::region::RegionOp::Union);
+            }
+        }
+
+        // After considering this node's damage, if the node itself is a
+        // valid opaque occluder, record its visible bounds.
+        if info.is_opaque {
+            let vb = info.visible_bounds;
+            if vb.width() > 0.0 && vb.height() > 0.0 {
+                occluder_shapes.push((info.node_ref, rect_to_irect(vb)));
+            }
+        }
+    }
+
+    // `collect_draw_order` skips hidden / fully-transparent subtrees, so
+    // nodes that just became hidden or faded to opacity 0 are not in
+    // `draw_order`. Their previous bounds still need to be damaged so the
+    // compositor clears the pixels they used to occupy. Union any such
+    // unvisited dirty node's damage unconditionally (it has no valid
+    // front-most ancestor to be clipped against).
+    for (node_ref, rect) in per_node_damage.iter() {
+        if visited.contains(node_ref) || rect.is_empty() {
+            continue;
+        }
+        damage.op_rect(rect_to_irect(*rect), skia_safe::region::RegionOp::Union);
+    }
+
+    let bounds = damage.bounds();
+    if bounds.is_empty() {
+        skia_safe::Rect::default()
+    } else {
+        skia_safe::Rect::from_irect(bounds)
+    }
+}
+
+/// Convert a floating-point rect to the integer rect that `skia::Region`
+/// requires. Rounds outward so the integer rect covers every pixel the
+/// float rect touches — never under-reports damage.
+fn rect_to_irect(r: skia_safe::Rect) -> skia_safe::IRect {
+    skia_safe::IRect::from_ltrb(
+        r.left.floor() as i32,
+        r.top.floor() as i32,
+        r.right.ceil() as i32,
+        r.bottom.ceil() as i32,
+    )
+}
+
+/// Returns `true` if `maybe_descendant` is a strict descendant of
+/// `ancestor` in the scene tree (i.e. lives in the subtree rooted at
+/// `ancestor` but is not `ancestor` itself). Walks `maybe_descendant`'s
+/// parent chain; bounded by tree depth, which is shallow in practice.
+fn is_descendant(maybe_descendant: NodeRef, ancestor: NodeRef, arena: &Arena<SceneNode>) -> bool {
+    if maybe_descendant == ancestor {
+        return false;
+    }
+    let ancestor_id: TreeStorageId = ancestor.into();
+    let mut current: TreeStorageId = maybe_descendant.into();
+    while let Some(node) = arena.get(current) {
+        match node.parent() {
+            Some(pid) => {
+                if pid == ancestor_id {
+                    return true;
+                }
+                current = pid;
+            }
+            None => return false,
+        }
+    }
+    false
+}
+
 struct NodeOcclusionInfo {
     node_ref: NodeRef,
     /// The node bounds intersected with the active clip (what is actually visible).

--- a/tests/damage.rs
+++ b/tests/damage.rs
@@ -1178,4 +1178,70 @@ mod tests {
             scene_damage
         );
     }
+
+    // -------------------------------------------------------------------
+    // Occlusion-aware damage — `Engine::compute_output_state`
+    //
+    // Single-pass walker that folds occlusion + per-output scene damage.
+    // When a layer is fully occluded by an opaque layer above, its damage
+    // must not appear in the returned scene damage region.
+    //
+    // v1 opaque criteria (hint-driven):
+    //   content_opaque == true
+    //   && premultiplied_opacity == 1.0
+    //   && blend_mode == Normal
+    //   && !hidden
+    // Occluder shape = the layer's global_transformed_bounds.
+    //
+    // See `project_occlusion_damage_plan.md` for full design.
+    // -------------------------------------------------------------------
+
+    /// A layer fully occluded by an opaque sibling above it must contribute
+    /// zero damage to the scene, even when its draw closure reports damage.
+    /// This is the starting TDD test — `engine.damage()` is expected to
+    /// fold occlusion into its result, so the consumer-visible API stays
+    /// the same and the effect is transparent.
+    #[test]
+    pub fn occluded_layer_damage_is_dropped_from_scene() {
+        let engine = Engine::create(1000.0, 1000.0);
+
+        // Back layer — will be fully occluded by `front`.
+        let back = engine.new_layer();
+        back.set_position((100.0, 100.0), None);
+        back.set_size(Size::points(200.0, 200.0), None);
+        back.set_background_color(
+            PaintColor::Solid {
+                color: Color::new_hex("#ff0000ff"),
+            },
+            None,
+        );
+        engine.add_layer(&back).unwrap();
+
+        // Front layer — same bounds as `back`, marked content_opaque so it
+        // acts as an occluder even with a transparent background.
+        let front = engine.new_layer();
+        front.set_position((100.0, 100.0), None);
+        front.set_size(Size::points(200.0, 200.0), None);
+        front.set_content_opaque(true);
+        engine.add_layer(&front).unwrap();
+
+        // First update to establish initial state; clear any startup damage.
+        engine.update(0.016);
+        engine.clear_damage();
+
+        // Report damage on `back` via its draw closure. `front` is unchanged.
+        let draw_func = |_c: &skia_safe::Canvas, _w: f32, _h: f32| -> skia_safe::Rect {
+            skia_safe::Rect::from_xywh(0.0, 0.0, 50.0, 50.0)
+        };
+        back.set_draw_content(draw_func);
+        engine.update(0.016);
+
+        let scene_damage = engine.damage();
+        assert!(
+            scene_damage.is_empty(),
+            "scene damage must be empty — back's damage is fully occluded by front, \
+             but got {:?}",
+            scene_damage
+        );
+    }
 }

--- a/tests/damage.rs
+++ b/tests/damage.rs
@@ -1205,8 +1205,17 @@ mod tests {
     pub fn occluded_layer_damage_is_dropped_from_scene() {
         let engine = Engine::create(1000.0, 1000.0);
 
+        // Explicit root so `back` and `front` are siblings, not parent/child.
+        let root = engine.new_layer();
+        root.set_size(Size::points(1000.0, 1000.0), None);
+        engine.add_layer(&root).unwrap();
+
         // Back layer — will be fully occluded by `front`.
         let back = engine.new_layer();
+        back.set_layout_style(layers::taffy::Style {
+            position: layers::taffy::Position::Absolute,
+            ..Default::default()
+        });
         back.set_position((100.0, 100.0), None);
         back.set_size(Size::points(200.0, 200.0), None);
         back.set_background_color(
@@ -1215,15 +1224,19 @@ mod tests {
             },
             None,
         );
-        engine.add_layer(&back).unwrap();
+        engine.append_layer(&back, root.id).unwrap();
 
         // Front layer — same bounds as `back`, marked content_opaque so it
         // acts as an occluder even with a transparent background.
         let front = engine.new_layer();
+        front.set_layout_style(layers::taffy::Style {
+            position: layers::taffy::Position::Absolute,
+            ..Default::default()
+        });
         front.set_position((100.0, 100.0), None);
         front.set_size(Size::points(200.0, 200.0), None);
         front.set_content_opaque(true);
-        engine.add_layer(&front).unwrap();
+        engine.append_layer(&front, root.id).unwrap();
 
         // First update to establish initial state; clear any startup damage.
         engine.update(0.016);


### PR DESCRIPTION
## Summary

Per-layer damage is now clipped by the running opaque-occluder region in a single front-to-back walk. Layers that are fully covered by an opaque layer in front of them contribute **nothing** to the scene damage; partially occluded layers contribute only their visible remainder. The effect is transparent: \`Engine::damage()\` returns an already-occlusion-aware rect.

## Motivation

Before this, scene damage was a straight union of every dirty node's rect in global coordinates. A background Wayland surface with cursor-blink or animation damage would always appear in the final frame damage — even if a foreground Chrome window was fully covering it — because the \`engine.damage()\` aggregation had no way to know about occlusion. Occlusion was only consulted at **draw** time (via \`render_node_tree\`) to skip painting occluded nodes, which saved nothing on the frame-damage passed to Smithay or on the number of pixels the DRM path re-scans/flips each vblank.

This change composes partial-damage reporting (landed in PR #18) with the already-existing opacity / occlusion model so the win stacks: a client's small animated rect is first scoped down to just the animated region, then dropped entirely if something in front of it covers that region.

## Algorithm

In \`occlusion::compute_occlusion_aware_damage\`:

1. Collect subtree in draw order (pre-order → back-to-front) via the existing \`collect_draw_order\`.
2. Iterate in reverse (front-to-back) with two accumulators:
   - \`occluder_shapes: Vec<(NodeRef, IRect)>\` — opaque shapes tagged by source node
   - \`damage: Region\` — the visible remainder so far
3. For each dirty node: build an *effective* occluder region from \`occluder_shapes\`, **excluding any shape whose tag is a descendant of the damaged node**, then subtract from the node's damage rect and union the remainder into \`damage\`.
4. If the node itself is a valid opaque occluder (v1 criteria: \`is_fully_opaque\` — i.e. \`content_opaque\` or opaque background, opacity == 1.0, blend == Normal, not hidden, not clipped out), record its \`visible_bounds\` in \`occluder_shapes\`.
5. Return the bounding rect of the final damage region.

### Why the descendant guard matters

Without it, an opaque child's bounds would wipe its own parent's damage when the parent had a color filter / effect change — because the parent's \"damage\" represents re-rendering the whole subtree (including the child) through the new filter. The child cannot legitimately occlude its ancestor. Tagging occluder shapes by source node and filtering at subtract time handles this correctly.

### Hidden-subtree fallback

\`collect_draw_order\` intentionally skips hidden / fully-transparent subtrees, so a node that just became hidden this frame isn't in the walk. Its previous bounds still need to be damaged so the compositor clears the old pixels. After the main walk, any dirty node that wasn't visited has its damage unioned in unconditionally.

### Integer conversion

Float rects are converted to \`IRect\` with outward rounding (\`floor\`/\`ceil\`) so the integer region never under-reports damage at sub-pixel boundaries.

## Tests

New test: \`occluded_layer_damage_is_dropped_from_scene\` — two sibling layers at the same bounds, \`front\` is \`content_opaque\`, \`back\`'s draw closure reports damage. Asserts \`engine.damage().is_empty()\`.

All 28 existing damage tests still pass, including:

- \`damage_opacity\` (layer fading out → previous bounds damaged even though subtree is skipped in draw order)
- \`damage_color_filter_container_no_background\` (filter container with opaque child → container's damage is **not** wiped by the child's occlusion, thanks to the descendant guard)

Full \`cargo test\` green.

## End-to-end validation in Otto

Patched Otto's \`Cargo.toml\` at this branch, rebuilt, ran \`spotify + chromium --start-maximized https://news.ycombinator.com\` on top. Scene perf counters during the stable state:

\`\`\`
u/s=3 changes=1 dmg=0 idle=2
u/s=4 changes=2 dmg=0 idle=2
u/s=3 changes=1 dmg=0 idle=2
...
\`\`\`

\`changes > 0\` with \`dmg = 0\` is the new steady state when a foreground window fully occludes a background one — every Spotify commit is eaten by the Chrome occluder. Measured:

| Metric | Side-by-side | Fullscreen-occluded |
|---|---|---|
| Otto CPU | 13.0 % | 2.6 % |
| scene updates/s | 30 | 3–4 |
| updates producing damage | 30/s | 0–1/s |
| GPU \`gt_act_freq\` | 1200–1300 MHz | **0 MHz (RC6 sleep)** |

## Limitations / follow-ups

- v1 only honors the \`content_opaque\` hint + opacity/blend/hidden checks. Doesn't yet consume \`wl_surface.set_opaque_region()\` or inscribe rounded corners. Both are incremental optimizations with separate payoffs.
- Skia \`Region\` is used throughout for arbitrary pixel sets; the returned \`Rect\` is its bounding box, so partially-occluded damage may still be reported as a slightly-larger AABB than the exact visible shape. Fine for v1.
- Multi-output scenes: \`Engine::update_nodes\` currently walks from the global scene root. Per-output subtrees (if Otto ever needs distinct occluder contexts per output) would need \`Engine::compute_output_state(root)\` — noted in the plan but not yet needed.

## Test plan

- [x] \`cargo test --test damage\` — 29/29 pass
- [x] \`cargo test\` — full crate green
- [x] \`cargo fmt --all --check\`
- [x] \`cargo clippy --all-targets\`
- [x] End-to-end in Otto: occluded Spotify → 0 scene damage, GPU in RC6, Otto CPU 2.6 %