### PR TITLE
chore: bump version to 1.12.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laye-rs"
-version = "1.11.0"
+version = "1.12.0"
 edition = "2021"
 build = "build.rs"
 rust-version = "1.85.0"


### PR DESCRIPTION
Bumps the crate version from 1.11.0 to 1.12.0 to reflect the backdrop blur performance improvement landed in the previous commit on `main`.